### PR TITLE
Dockerize the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,20 @@
-FROM oven/bun:1.2.5 AS base
-WORKDIR /usr/src/app
+FROM oven/bun:alpine AS builder
+WORKDIR /app
 
-FROM base AS install
-COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production
+COPY ./package.json ./bun.lock ./
+RUN bun install --frozen-lockfile
 
-
-FROM base AS prerelease
-COPY --from=install /usr/src/app/node_modules node_modules
 COPY . .
-
-ENV NODE_ENV=production
-RUN bun test
 RUN bun run build
 
-FROM base AS release
-COPY --from=install /usr/src/app/node_modules node_modules
-COPY --from=prerelease /usr/src/app/dist/ .
+FROM oven/bun:alpine AS runner
+WORKDIR /app
 
-USER bun
-EXPOSE 4141/tcp
-ENTRYPOINT [ "bun", "main.js"]
+COPY ./package.json ./bun.lock ./
+RUN bun install --frozen-lockfile --production --ignore-scripts --no-cache
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 4141
+
+CMD ["bun", "run", "dist/main.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:slim
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN bun install
+
+COPY src ./src
+COPY tsconfig.json ./
+
+EXPOSE 4141
+
+ENV NODE_ENV=production
+
+CMD ["bun", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ To install dependencies, run:
 bun install
 ```
 
+## Using with docker
+
+Build image
+
+```sh
+docker build -t copilot-api .
+```
+
+Run the container
+
+```sh
+docker run -p 4141:4141 copilot-api
+```
+
 ## Using with npx
 
 You can run the project directly using npx:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "knip": "knip-bun",
     "lint": "eslint .",
     "prepack": "bun run build",
-    "prepare": "simple-git-hooks",
+    "prepare": "NODE_ENV=production || simple-git-hooks",
     "release": "bumpp && bun publish --access public",
     "start": "NODE_ENV=production bun run ./src/main.ts"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "knip": "knip-bun",
     "lint": "eslint .",
     "prepack": "bun run build",
-    "prepare": "NODE_ENV=production || simple-git-hooks",
+    "prepare": "simple-git-hooks",
     "release": "bumpp && bun publish --access public",
     "start": "NODE_ENV=production bun run ./src/main.ts"
   },


### PR DESCRIPTION
This PR adds a Dockerfile to dockerize the application using the oven/bun:slim image. It sets up the working directory, installs dependencies, configures the production environment, and defines the start command.