### PR TITLE
A fix for countTokens and a dockerfile improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ COPY --from=builder /app/dist ./dist
 
 EXPOSE 4141
 
-CMD ["bun", "run", "dist/main.js"]
+ARG GH_TOKEN
+ENV GH_TOKEN=$GH_TOKEN
+
+CMD bun run dist/main.js start -g $GH_TOKEN --vision

--- a/src/lib/tokenizer.ts
+++ b/src/lib/tokenizer.ts
@@ -3,7 +3,10 @@ import { countTokens } from "gpt-tokenizer/model/gpt-4o"
 import type { Message } from "~/services/copilot/create-chat-completions"
 
 export const getTokenCount = (messages: Array<Message>) => {
-  const input = messages.filter((m) => m.role !== "assistant")
+  const input = messages.filter(
+    (m) => m.role !== "assistant" && typeof m.content === "string",
+  )
+  console.log(input)
   const output = messages.filter((m) => m.role === "assistant")
 
   const inputTokens = countTokens(input)


### PR DESCRIPTION
Without this fix I got a 500 error when trying to upload images because the input would be an array that contained the image and the text.

I also added a Dockerfile argument to use it with docker compose. Example usage:
```
  copilot:
    build:
      context: ./copilot-api
      dockerfile: Dockerfile
      args:
        GH_TOKEN: ${GH_TOKEN}
    container_name: copilot
    env_file:
      - .env
    ports:
      - "4141:4141"
```