### PR TITLE
Implement dynamic vision capability enablement

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,25 @@
+{
+  "semi": false,
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "trailingComma": "all",
+  "useTabs": false,
+  "quoteProps": "preserve",
+  "overrides": [
+    {
+      "files": [".vscode/*.json"],
+      "options": {
+        "parser": "jsonc",
+        "quoteProps": "preserve",
+        "singleQuote": false,
+        "trailingComma": "all"
+      }
+    },
+    {
+      "files": ["*.md"],
+      "options": {
+        "printWidth": 80
+      }
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ EXPOSE 4141
 ARG GH_TOKEN
 ENV GH_TOKEN=$GH_TOKEN
 
-CMD bun run dist/main.js start -g $GH_TOKEN --vision
+CMD bun run dist/main.js start -g $GH_TOKEN

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ The following command line options are available for the `start` command:
 | --rate-limit   | Rate limit in seconds between requests                                        | none    | -r    |
 | --wait         | Wait instead of error when rate limit is hit                                  | false   | -w    |
 | --github-token | Provide GitHub token directly (must be generated using the `auth` subcommand) | none    | -g    |
-| --vision       | Enable vision capabilities                                                    | false   | none  |
 
 ### Auth Command Options
 
@@ -115,9 +114,6 @@ npx copilot-api@latest start --rate-limit 30 --wait
 
 # Provide GitHub token directly
 npx copilot-api@latest start --github-token ghp_YOUR_TOKEN_HERE
-
-# Enable vision capabilities
-npx copilot-api@latest start --vision
 
 # Run only the auth flow
 npx copilot-api@latest auth

--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -15,7 +15,7 @@ const API_VERSION = "2025-04-01"
 
 export const copilotBaseUrl = (state: State) =>
   `https://api.${state.accountType}.githubcopilot.com`
-export const copilotHeaders = (state: State) => {
+export const copilotHeaders = (state: State, vision: boolean = false) => {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${state.copilotToken}`,
     "content-type": standardHeaders()["content-type"],
@@ -29,9 +29,7 @@ export const copilotHeaders = (state: State) => {
     "x-vscode-user-agent-library-version": "electron-fetch",
   }
 
-  if (state.visionEnabled) {
-    headers["copilot-vision-request"] = "true"
-  }
+  if (vision) headers["copilot-vision-request"] = "true"
 
   return headers
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -10,7 +10,6 @@ export interface State {
 
   manualApprove: boolean
   rateLimitWait: boolean
-  visionEnabled: boolean
 
   // Rate limiting configuration
   rateLimitSeconds?: number
@@ -21,5 +20,4 @@ export const state: State = {
   accountType: "individual",
   manualApprove: false,
   rateLimitWait: false,
-  visionEnabled: false,
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,6 @@ interface RunServerOptions {
   rateLimit?: number
   rateLimitWait: boolean
   githubToken?: string
-  visionEnabled: boolean
 }
 
 export async function runServer(options: RunServerOptions): Promise<void> {
@@ -37,11 +36,6 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   state.manualApprove = options.manual
   state.rateLimitSeconds = options.rateLimit
   state.rateLimitWait = options.rateLimitWait
-  state.visionEnabled = options.visionEnabled
-
-  if (options.visionEnabled) {
-    consola.info("Vision capability enabled")
-  }
 
   await ensurePaths()
   await cacheVSCodeVersion()
@@ -111,12 +105,6 @@ const start = defineCommand({
       description:
         "Provide GitHub token directly (must be generated using the `auth` subcommand)",
     },
-    vision: {
-      type: "boolean",
-      default: false,
-      description: "Enable vision capabilities",
-      required: false,
-    },
   },
   run({ args }) {
     const rateLimitRaw = args["rate-limit"]
@@ -134,7 +122,6 @@ const start = defineCommand({
       rateLimit,
       rateLimitWait: Boolean(args.wait),
       githubToken: args["github-token"],
-      visionEnabled: args.vision,
     })
   },
 })


### PR DESCRIPTION
See #36.

Also, during my development, I setup `.prettierrc` for zed(editor) to develop without additional configuration.

> bun's `.prettierrc`: https://github.com/oven-sh/bun/blob/main/.prettierrc

close #36 