### PR TITLE
feat: allow use of GitHub enterprise account type endpoint

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ interface RunServerOptions {
   port: number
   verbose: boolean
   business: boolean
+  enterprise: boolean
   manual: boolean
   rateLimit?: number
   rateLimitWait: boolean
@@ -31,6 +32,9 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   if (options.business) {
     state.accountType = "business"
     consola.info("Using business plan GitHub account")
+  } else if (options.enterprise) {
+    state.accountType = "enterprise"
+    consola.info("Using enterprise plan GitHub account")
   }
 
   state.manualApprove = options.manual
@@ -82,6 +86,11 @@ const start = defineCommand({
       default: false,
       description: "Use a business plan GitHub Account",
     },
+    enterprise: {
+      type: "boolean",
+      default: false,
+      description: "Use a enterprise plan GitHub Account",
+    },
     manual: {
       type: "boolean",
       default: false,
@@ -118,6 +127,7 @@ const start = defineCommand({
       port,
       verbose: args.verbose,
       business: args.business,
+      enterprise: args.enterprise,
       manual: args.manual,
       rateLimit,
       rateLimitWait: Boolean(args.wait),


### PR DESCRIPTION
There's support for business accounts via `--business`, this PR adds support for enterprise accounts by adding `--enterprise`.

This could potentially be a fix the persistent issues described in #19 and #39.

There are plenty of more elegant ways of implementing this but I didn't want to do a refactor of the existing code out of the blue. For a potential future refactor I'd suggest rather than accepting `--business` or `--enterprise` on the cli to allow to specify the endpoint URL to use. Alternatively, a `--type business|enterprise` parameter might be a better approach.

**Background**:
The [documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-access-to-github-copilot-in-your-organization/managing-github-copilot-access-to-your-organizations-network?versionId=enterprise-cloud%40latest&productId=copilot&restPage=managing-copilot%2Cmanaging-copilot-for-your-enterprise%2Cmanaging-access-to-copilot-in-your-enterprise%2Cmanaging-github-copilot-access-to-your-enterprises-network#configuring-copilot-subscription-based-network-routing-for-your-enterprise-or-organization) lists `*.enterprise.githubcopilot.com` as the endpoints for the enterprise plan as API calls using enterprise and business accounts must be directed towards the correct endpoint.