### PR TITLE
Add advanced request usage query to display remaining quota via the web version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 A reverse-engineered proxy for the GitHub Copilot API that exposes it as an OpenAI and Anthropic compatible service. This allows you to use GitHub Copilot with any tool that supports the OpenAI Chat Completions API or the Anthropic Messages API, including to power [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview).
 
+### New Features
+
+- **Copilot Usage Viewer**: Integrated web interface to view your GitHub Copilot usage statistics and quota information
+- **Token Display**: View the current Copilot token being used by the API
+- **Real-time Monitoring**: Track your usage and remaining quotas in real-time
+
 ## Demo
 
 https://github.com/user-attachments/assets/7654b383-669d-4eb9-b23c-06d7aefee8c5
@@ -113,6 +119,16 @@ These endpoints are designed to be compatible with the Anthropic Messages API.
 | `POST /v1/messages`              | `POST` | Creates a model response for a given conversation.           |
 | `POST /v1/messages/count_tokens` | `POST` | Calculates the number of tokens for a given set of messages. |
 
+### Usage Monitoring Endpoints
+
+New endpoints for monitoring your Copilot usage and quotas.
+
+| Endpoint                    | Method | Description                                               |
+| --------------------------- | ------ | --------------------------------------------------------- |
+| `GET /usage`               | `GET`  | Get detailed Copilot usage statistics and quota information. |
+| `GET /token`               | `GET`  | Get the current Copilot token being used by the API.     |
+| `GET /public/usage.html`   | `GET`  | Web interface for viewing usage statistics (accessible via browser). |
+
 ## Example Usage
 
 Using with npx:
@@ -148,6 +164,34 @@ npx copilot-api@latest auth
 # Run auth flow with verbose logging
 npx copilot-api@latest auth --verbose
 ```
+
+## Using the Usage Viewer
+
+After starting the server, you can access the Copilot Usage Viewer through your web browser:
+
+1. Start the server: `npx copilot-api@latest start`
+2. Open your browser and navigate to: `http://localhost:4141/public/usage.html`
+3. The page will automatically load your usage data when opened
+4. Use the controls to:
+   - **Fetch Usage**: Manually refresh usage data
+   - **Show Current Token**: View the current Copilot token
+   - **Enable Auto Refresh**: Automatically refresh data every 30 seconds
+
+### Auto Refresh Feature
+
+The usage viewer includes an automatic refresh feature that:
+- Updates usage data every 30 seconds when enabled
+- Shows a countdown timer to the next refresh
+- Displays the last update time
+- Can be toggled on/off at any time
+- Continues running in the background without interrupting your view
+
+The usage viewer provides:
+- Account information (plan type, access type, assigned date)
+- Quota information (remaining usage, total quota, overage count)
+- Real-time token display with automatic refresh
+- Support for Chinese and English interfaces
+- Auto-refresh functionality for continuous monitoring
 
 ## Using with Claude Code
 

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -19,13 +19,19 @@ export const setupCopilotToken = async () => {
   const { token, refresh_in } = await getCopilotToken()
   state.copilotToken = token
 
-  const refreshInterval = (refresh_in - 60) * 1000
+  // Display the Copilot token to the screen
+  consola.success("GitHub Copilot Token fetched successfully!")
+  consola.info(`Token: ${token}`)
+  consola.info(`Token validity: ${Math.floor(refresh_in / 60)} minutes`)
 
+  const refreshInterval = (refresh_in - 60) * 1000
   setInterval(async () => {
     consola.start("Refreshing Copilot token")
     try {
       const { token } = await getCopilotToken()
       state.copilotToken = token
+      consola.success("Copilot token refreshed")
+      consola.info(`New Token: ${token}`)
     } catch (error) {
       consola.error("Failed to refresh Copilot token:", error)
       throw error

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,10 +49,13 @@ export async function runServer(options: RunServerOptions): Promise<void> {
     consola.info("Using provided GitHub token")
   } else {
     await setupGitHubToken()
-  }
-
-  await setupCopilotToken()
-  await cacheModels()
+  }  await setupCopilotToken()
+  await cacheModels()  // Display token information prominently
+  consola.info("=".repeat(50))
+  consola.success("🚀 GitHub Copilot API has been successfully started!")
+  consola.info(`🔑 Current Copilot Token: ${state.copilotToken}`)
+  consola.info(`🌐 Usage Viewer: http://localhost:${options.port}/public/usage.html`)
+  consola.info("=".repeat(50))
 
   consola.info(
     `Available models: \n${state.models?.data.map((model) => `- ${model.id}`).join("\n")}`,

--- a/src/public/usage.html
+++ b/src/public/usage.html
@@ -1,0 +1,633 @@
+<!DOCTYPE html>
+<!-- @ts-nocheck -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GitHub Copilot Usage Viewer</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f6f8fa;
+      color: #24292f;
+      line-height: 1.5;
+      padding: 20px;
+    }
+
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    .header {
+      text-align: center;
+      margin-bottom: 32px;
+    }
+
+    .header h1 {
+      font-size: 28px;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+
+    .control-section {
+      background: white;
+      border: 1px solid #d0d7de;
+      border-radius: 8px;
+      padding: 24px;
+      margin-bottom: 24px;
+      text-align: center;
+    }
+
+    .btn {
+      background: #0969da;
+      color: white;
+      border: none;
+      padding: 12px 20px;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+
+    .btn:hover {
+      background: #0550ae;
+    }    .btn:disabled {
+      background: #8c959f;
+      cursor: not-allowed;
+    }
+
+    .btn.danger {
+      background: #cf222e;
+    }
+
+    .btn.danger:hover {
+      background: #a40e26;
+    }
+
+    .auto-refresh-status {
+      margin-top: 10px;
+      font-size: 12px;
+      color: #656d76;
+      text-align: center;
+    }
+
+    .countdown {
+      font-weight: 500;
+      color: #0969da;
+    }
+
+    .result {
+      background: white;
+      border: 1px solid #d0d7de;
+      border-radius: 8px;
+      overflow: hidden;
+      display: none;
+    }
+
+    .result-header {
+      background: #f6f8fa;
+      border-bottom: 1px solid #d0d7de;
+      padding: 16px 24px;
+      font-weight: 600;
+    }
+
+    .info-section {
+      padding: 24px;
+    }
+
+    .info-row {
+      display: flex;
+      justify-content: space-between;
+      padding: 12px 0;
+      border-bottom: 1px solid #f6f8fa;
+    }
+
+    .info-row:last-child {
+      border-bottom: none;
+    }
+
+    .info-label {
+      color: #656d76;
+      font-size: 14px;
+    }
+
+    .info-value {
+      font-weight: 500;
+      font-size: 14px;
+    }
+
+    .quota-section {
+      border-top: 1px solid #d0d7de;
+      background: #f6f8fa;
+      padding: 24px;
+    }
+
+    .quota-title {
+      font-weight: 600;
+      margin-bottom: 16px;
+      font-size: 16px;
+    }
+
+    .quota-item {
+      background: white;
+      border: 1px solid #d0d7de;
+      border-radius: 6px;
+      padding: 16px;
+      margin-bottom: 12px;
+    }
+
+    .quota-item:last-child {
+      margin-bottom: 0;
+    }
+
+    .quota-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 12px;
+    }
+
+    .quota-name {
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .quota-badge {
+      font-size: 12px;
+      font-weight: 500;
+      padding: 4px 8px;
+      border-radius: 12px;
+    }
+
+    .unlimited {
+      background: #dafbe1;
+      color: #116329;
+    }
+
+    .limited {
+      background: #fff8c5;
+      color: #7d4e00;
+    }
+
+    .quota-progress {
+      height: 6px;
+      background: #eaeef2;
+      border-radius: 3px;
+      margin-bottom: 12px;
+      overflow: hidden;
+    }
+
+    .progress-fill {
+      height: 100%;
+      background: #1f883d;
+      transition: width 0.3s ease;
+    }
+
+    .quota-stats {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+    }
+
+    .stat {
+      text-align: center;
+      padding: 8px;
+      background: #f6f8fa;
+      border-radius: 4px;
+    }
+
+    .stat-value {
+      font-weight: 600;
+      font-size: 16px;
+    }
+
+    .stat-label {
+      font-size: 12px;
+      color: #656d76;
+      margin-top: 2px;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 40px 24px;
+      color: #656d76;
+    }
+
+    .spinner {
+      border: 2px solid #f6f8fa;
+      border-top: 2px solid #0969da;
+      border-radius: 50%;
+      width: 20px;
+      height: 20px;
+      animation: spin 1s linear infinite;
+      margin: 0 auto 12px;
+    }
+
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+
+    .error {
+      background: #ffebe9;
+      color: #cf222e;
+      padding: 16px 24px;
+      border-left: 3px solid #cf222e;
+      margin: 20px 0;
+      border-radius: 4px;
+    }
+
+    .footer {
+      text-align: center;
+      margin-top: 40px;
+      padding: 20px;
+      color: #656d76;
+      font-size: 14px;
+    }
+
+    .footer a {
+      color: #0969da;
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .footer a:hover {
+      text-decoration: underline;
+    }
+
+    .token-display {
+      background: #f6f8fa;
+      border: 1px solid #d0d7de;
+      border-radius: 6px;
+      padding: 12px;
+      margin-bottom: 16px;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+      font-size: 12px;
+      word-break: break-all;
+    }
+
+    .token-label {
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: #24292f;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1 id="title">GitHub Copilot Usage Viewer</h1>
+    </div>    <div class="control-section">
+      <button id="fetchBtn" class="btn" onclick="fetchUsage()">Fetch Usage</button>
+      <button id="tokenBtn" class="btn" onclick="fetchToken()" style="margin-left: 10px;">Show Current Token</button>
+      <button id="autoBtn" class="btn" onclick="toggleAutoRefresh()" style="margin-left: 10px;">Enable Auto Refresh</button>
+      <div style="margin-top: 10px; font-size: 12px; color: #656d76;">
+        <span id="autoStatus">Auto Refresh: Off</span>
+        <span id="countdown" style="margin-left: 15px;"></span>
+      </div>
+    </div>    <div id="tokenResult" class="result" style="display: none;">
+      <div class="result-header">
+        Current Copilot Token Information
+      </div>
+      <div class="info-section">
+        <div class="token-label">Token:</div>
+        <div class="token-display" id="tokenDisplay"></div>
+        <small style="color: #656d76;">Note: This token is automatically refreshed periodically</small>
+      </div>
+    </div>
+
+    <div id="result" class="result"></div>    <div class="footer">
+      <a href="https://github.com/uheej0625/copilot-usage-viewer" target="_blank">
+        Based on copilot-usage-viewer project
+      </a>
+    </div>
+  </div>
+  <script>
+    // @ts-nocheck
+    // Language detection and translations
+    const lang = 'en'; // Default to English
+
+    const translations = {
+      en: {
+        title: 'GitHub Copilot Usage Viewer',
+        fetchBtn: 'Fetch Usage',
+        loading: 'Loading data...',
+        error: 'An error occurred',
+        accountInfo: 'Account Information',
+        quotaInfo: 'Quota Information',
+        plan: 'Plan',
+        accessType: 'Access Type',
+        assignedDate: 'Assigned Date',
+        chatEnabled: 'Chat Enabled',
+        quotaResetDate: 'Quota Reset Date',
+        canSignupLimited: 'Can Signup for Limited',
+        orgCount: 'Organization Count',
+        unlimited: 'Unlimited',
+        limited: 'Limited',
+        remaining: 'Remaining',
+        totalQuota: 'Total Quota',
+        overageCount: 'Overage Count',
+        remainingPercent: 'Remaining %',
+        yes: 'Yes',
+        no: 'No',
+        premiumInteractions: 'Premium Interactions',
+        chat: 'Chat',
+        completions: 'Completions',
+        currentToken: 'Current Copilot Token'
+      },
+      zh: {
+        title: 'GitHub Copilot Usage Viewer',
+        fetchBtn: 'Fetch Usage',
+        loading: 'Loading data...',
+        error: 'An error occurred',
+        accountInfo: 'Account Information',
+        quotaInfo: 'Quota Information',
+        plan: 'Plan',
+        accessType: 'Access Type',
+        assignedDate: 'Assigned Date',
+        chatEnabled: 'Chat Enabled',
+        quotaResetDate: 'Quota Reset Date',
+        canSignupLimited: 'Can Signup for Limited',
+        orgCount: 'Organization Count',
+        unlimited: 'Unlimited',
+        limited: 'Limited',
+        remaining: 'Remaining',
+        totalQuota: 'Total Quota',
+        overageCount: 'Overage Count',
+        remainingPercent: 'Remaining %',
+        yes: 'Yes',
+        no: 'No',
+        premiumInteractions: 'Premium Interactions',
+        chat: 'Chat',
+        completions: 'Completions',
+        currentToken: 'Current Copilot Token'
+      }
+    };
+
+    const t = translations[lang];    // Initialize UI text
+    document.getElementById('title').textContent = t.title;
+    document.getElementById('fetchBtn').textContent = t.fetchBtn;
+
+    // Auto refresh variables
+    let autoRefreshInterval = null;
+    let countdownInterval = null;    let isAutoRefreshEnabled = false;
+    let nextRefreshTime = 0;
+    const REFRESH_INTERVAL = 30000; // 30 seconds
+      function updateAutoRefreshUI() {
+      const autoBtn = document.getElementById('autoBtn');
+      const autoStatus = document.getElementById('autoStatus');
+      
+      if (isAutoRefreshEnabled) {
+        autoBtn.textContent = 'Disable Auto Refresh';
+        autoBtn.className = 'btn danger';
+        autoStatus.textContent = 'Auto Refresh: On (30s interval)';
+      } else {
+        autoBtn.textContent = 'Enable Auto Refresh';
+        autoBtn.className = 'btn';
+        autoStatus.textContent = 'Auto Refresh: Off';
+      }
+    }    function updateCountdown() {
+      const countdown = document.getElementById('countdown');
+      if (!isAutoRefreshEnabled) {
+        countdown.textContent = '';
+        return;
+      }
+      
+      const remaining = Math.max(0, Math.ceil((nextRefreshTime - Date.now()) / 1000));
+      if (remaining > 0) {
+        countdown.textContent = `Next refresh: ${remaining}s`;
+      } else {
+        countdown.textContent = 'Refreshing...';
+      }
+    }
+
+    function startAutoRefresh() {
+      if (autoRefreshInterval) return;
+      
+      isAutoRefreshEnabled = true;
+      nextRefreshTime = Date.now() + REFRESH_INTERVAL;
+        // Start the refresh interval
+      autoRefreshInterval = setInterval(() => {
+        fetchUsage(true); // Pass true to indicate this is an auto refresh
+        nextRefreshTime = Date.now() + REFRESH_INTERVAL;
+      }, REFRESH_INTERVAL);
+      
+      // Start the countdown interval
+      countdownInterval = setInterval(updateCountdown, 1000);
+      
+      updateAutoRefreshUI();
+      updateCountdown();
+        // Fetch immediately when starting auto refresh
+      fetchUsage(false); // First call is manual, so show loading
+    }
+
+    function stopAutoRefresh() {
+      if (autoRefreshInterval) {
+        clearInterval(autoRefreshInterval);
+        autoRefreshInterval = null;
+      }
+      
+      if (countdownInterval) {
+        clearInterval(countdownInterval);
+        countdownInterval = null;
+      }
+      
+      isAutoRefreshEnabled = false;
+      updateAutoRefreshUI();
+      updateCountdown();
+    }
+
+    function toggleAutoRefresh() {
+      if (isAutoRefreshEnabled) {
+        stopAutoRefresh();
+      } else {
+        startAutoRefresh();
+      }
+    }    // Initialize auto refresh UI
+    updateAutoRefreshUI();
+
+    // Auto-fetch data on page load
+    window.addEventListener('DOMContentLoaded', function() {
+      // Wait a moment for the server to be ready, then fetch initial data
+      setTimeout(() => {
+        fetchUsage(false);
+      }, 1000);
+    });
+
+    function getQuotaName(key) {
+      const names = {
+        'premium_interactions': t.premiumInteractions,
+        'chat': t.chat,
+        'completions': t.completions
+      };
+      return names[key] || key.replace('_', ' ');
+    }
+
+    function formatDate(dateString) {
+      if (!dateString) return 'N/A';
+      const date = new Date(dateString);
+      return lang === 'zh' ? date.toLocaleDateString('zh-CN') : date.toLocaleDateString('en-US');
+    }    async function fetchToken() {
+      const tokenResult = document.getElementById('tokenResult');
+      const tokenDisplay = document.getElementById('tokenDisplay');
+      
+      try {
+        const response = await fetch('/token');
+        
+        if (response.ok) {
+          const data = await response.json();
+          tokenDisplay.textContent = data.token || 'Unable to get token';
+          tokenResult.style.display = 'block';
+        } else {
+          tokenDisplay.textContent = 'Failed to get token';
+          tokenResult.style.display = 'block';
+        }
+      } catch (error) {
+        tokenDisplay.textContent = `Error: ${error.message}`;
+        tokenResult.style.display = 'block';
+      }
+    }async function fetchUsage(isAutoRefresh = false) {
+      const resultDiv = document.getElementById('result');
+      const fetchBtn = document.getElementById('fetchBtn');
+
+      // Only show loading state if not auto refresh
+      if (!isAutoRefresh) {
+        fetchBtn.disabled = true;
+        fetchBtn.textContent = t.loading;
+        resultDiv.innerHTML = `
+          <div class="loading">
+            <div class="spinner"></div>
+            <div>${t.loading}</div>
+          </div>
+        `;
+        resultDiv.style.display = 'block';
+      }
+
+      try {
+        const response = await fetch('/usage');
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        displayResult(data, isAutoRefresh);
+      } catch (error) {
+        let errorMessage = `${t.error}: ${error.message}`;
+        resultDiv.innerHTML = `<div class="error">${errorMessage}</div>`;
+        resultDiv.style.display = 'block';
+      } finally {
+        if (!isAutoRefresh) {
+          fetchBtn.disabled = false;
+          fetchBtn.textContent = t.fetchBtn;
+        }
+      }
+    }    function displayResult(data, isAutoRefresh = false) {
+      const resultDiv = document.getElementById('result');
+      
+      // Get current time for last updated display
+      const now = new Date();
+      const timeString = now.toLocaleTimeString(lang === 'zh' ? 'zh-CN' : 'en-US');
+      
+      // Sort quotas to show premium_interactions first
+      const quotas = Object.entries(data.quota_snapshots || {})
+        .sort(([a], [b]) => a === 'premium_interactions' ? -1 : b === 'premium_interactions' ? 1 : 0);
+
+      const quotaCards = quotas.map(([key, quota]) => {
+        const isUnlimited = quota.unlimited;
+        const progressPercent = isUnlimited ? 100 : quota.percent_remaining;
+        
+        return `
+          <div class="quota-item">
+            <div class="quota-header">
+              <div class="quota-name">${getQuotaName(key)}</div>
+              <div class="quota-badge ${isUnlimited ? 'unlimited' : 'limited'}">
+                ${isUnlimited ? t.unlimited : t.limited}
+              </div>
+            </div>
+            
+            ${!isUnlimited ? `
+              <div class="quota-progress">
+                <div class="progress-fill" style="width: ${progressPercent}%"></div>
+              </div>
+            ` : ''}
+            
+            <div class="quota-stats">
+              <div class="stat">
+                <div class="stat-value">${isUnlimited ? '∞' : quota.remaining}</div>
+                <div class="stat-label">${t.remaining}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-value">${isUnlimited ? '∞' : quota.entitlement}</div>
+                <div class="stat-label">${t.totalQuota}</div>
+              </div>
+              ${!isUnlimited ? `
+                <div class="stat">
+                  <div class="stat-value">${quota.overage_count}</div>
+                  <div class="stat-label">${t.overageCount}</div>
+                </div>
+                <div class="stat">
+                  <div class="stat-value">${progressPercent.toFixed(1)}%</div>
+                  <div class="stat-label">${t.remainingPercent}</div>
+                </div>
+              ` : ''}
+            </div>
+          </div>
+        `;
+      }).join('');      resultDiv.innerHTML = `
+        <div class="result-header">
+          ${t.accountInfo}
+          <div style="float: right; font-size: 12px; font-weight: normal; color: #656d76;">
+            Last Updated: ${timeString}
+          </div>
+        </div>
+        <div class="info-section">
+          <div class="info-row">
+            <span class="info-label">${t.plan}</span>
+            <span class="info-value">${data.copilot_plan || 'N/A'}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">${t.accessType}</span>
+            <span class="info-value">${data.access_type_sku || 'N/A'}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">${t.assignedDate}</span>
+            <span class="info-value">${formatDate(data.assigned_date)}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">${t.chatEnabled}</span>
+            <span class="info-value">${data.chat_enabled ? t.yes : t.no}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">${t.quotaResetDate}</span>
+            <span class="info-value">${data.quota_reset_date || 'N/A'}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">${t.canSignupLimited}</span>
+            <span class="info-value">${data.can_signup_for_limited ? t.yes : t.no}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">${t.orgCount}</span>
+            <span class="info-value">${(data.organization_list || []).length}</span>
+          </div>
+        </div>
+        
+        <div class="quota-section">
+          <div class="quota-title">${t.quotaInfo}</div>
+          ${quotaCards}
+        </div>
+      `;
+      
+      resultDiv.style.display = 'block';
+    }
+  </script>
+</body>
+</html>

--- a/src/routes/token/route.ts
+++ b/src/routes/token/route.ts
@@ -1,0 +1,19 @@
+import { Hono } from "hono"
+import { state } from "~/lib/state"
+
+export const tokenRoute = new Hono()
+
+tokenRoute.get("/", async (c) => {
+  try {
+    return c.json({
+      token: state.copilotToken || "No token available",
+      hasToken: !!state.copilotToken
+    })
+  } catch (error) {
+    console.error("Error fetching token:", error)
+    return c.json(
+      { error: "Failed to fetch token", token: null },
+      500
+    )
+  }
+})

--- a/src/routes/usage/route.ts
+++ b/src/routes/usage/route.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono"
+import { getCopilotUsage } from "~/services/github/get-copilot-usage"
+
+export const usageRoute = new Hono()
+
+usageRoute.get("/", async (c) => {
+  try {
+    const usage = await getCopilotUsage()
+    return c.json(usage)
+  } catch (error) {
+    console.error("Error fetching Copilot usage:", error)
+    return c.json(
+      { error: "Failed to fetch Copilot usage" },
+      500
+    )
+  }
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,14 @@
 import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
+import { serveStatic } from "hono/bun"
 
 import { completionRoutes } from "./routes/chat-completions/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
 import { modelRoutes } from "./routes/models/route"
+import { usageRoute } from "./routes/usage/route"
+import { tokenRoute } from "./routes/token/route"
 
 export const server = new Hono()
 
@@ -14,14 +17,21 @@ server.use(cors())
 
 server.get("/", (c) => c.text("Server running"))
 
+// Serve static files from public directory
+server.use("/public/*", serveStatic({ root: "./src" }))
+
 server.route("/chat/completions", completionRoutes)
 server.route("/models", modelRoutes)
 server.route("/embeddings", embeddingRoutes)
+server.route("/usage", usageRoute)
+server.route("/token", tokenRoute)
 
 // Compatibility with tools that expect v1/ prefix
 server.route("/v1/chat/completions", completionRoutes)
 server.route("/v1/models", modelRoutes)
 server.route("/v1/embeddings", embeddingRoutes)
+server.route("/v1/usage", usageRoute)
+server.route("/v1/token", tokenRoute)
 
 // Anthropic compatible endpoints
 server.route("/v1/messages", messageRoutes)

--- a/src/services/github/get-copilot-usage.ts
+++ b/src/services/github/get-copilot-usage.ts
@@ -1,0 +1,37 @@
+import { GITHUB_API_BASE_URL, githubHeaders } from "~/lib/api-config"
+import { HTTPError } from "~/lib/error"
+import { state } from "~/lib/state"
+
+export interface CopilotUsageResponse {
+  copilot_plan: string
+  access_type_sku: string
+  assigned_date: string
+  chat_enabled: boolean
+  quota_reset_date: string
+  can_signup_for_limited: boolean
+  organization_list: string[]
+  quota_snapshots: {
+    [key: string]: {
+      unlimited: boolean
+      remaining: number
+      entitlement: number
+      overage_count: number
+      percent_remaining: number
+    }
+  }
+}
+
+export const getCopilotUsage = async (): Promise<CopilotUsageResponse> => {
+  const response = await fetch(
+    `${GITHUB_API_BASE_URL}/copilot_internal/user`,
+    {
+      headers: githubHeaders(state),
+    },
+  )
+
+  if (!response.ok) {
+    throw new HTTPError("Failed to get Copilot usage", response)
+  }
+
+  return (await response.json()) as CopilotUsageResponse
+}

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,20 @@
+@echo off
+echo ================================================
+echo GitHub Copilot API Server with Usage Viewer
+echo ================================================
+echo.
+
+if not exist node_modules (
+    echo Installing dependencies...
+    npm install
+    echo.
+)
+
+echo Starting server...
+echo The usage viewer page will open automatically after the server starts
+echo.
+
+start "" "http://localhost:4141/public/usage.html"
+npm run dev
+
+pause

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,17 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-
+    "noUncheckedSideEffectImports": true,    
     "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"]
     }
-  }
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Referenced the project at https://github.com/uheej0625/copilot-usage-viewer and merged it into this project.
You can view the webpage at http://localhost:4141/public/usage.html.

- **Copilot Usage Viewer**: Integrated web interface to view your GitHub Copilot usage statistics and quota information
- **Token Display**: View the current Copilot token being used by the API
- **Real-time Monitoring**: Track your usage and remaining quotas in real-time
- 
![image](https://github.com/user-attachments/assets/69d44278-3b86-4ed9-82f0-6f2675d2510a)
![image](https://github.com/user-attachments/assets/70232135-84dc-44af-88ca-d0409979680e)
