### PR TITLE
fix: Remove bun.lock from Dockerfile to fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM oven/bun:1.2.19-alpine AS builder
 WORKDIR /app
 
-COPY ./package.json ./bun.lock ./
+COPY ./package.json ./
 RUN bun install --frozen-lockfile
 
 COPY . .
@@ -10,7 +10,7 @@ RUN bun run build
 FROM oven/bun:1.2.19-alpine AS runner
 WORKDIR /app
 
-COPY ./package.json ./bun.lock ./
+COPY ./package.json ./
 RUN bun install --frozen-lockfile --production --ignore-scripts --no-cache
 
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
```
❯ docker build -t copilot-api .
[+] Building 2.9s (7/12)                                                                          docker:desktop-linux
 => [internal] load .dockerignore                                                                                 0.0s
 => => transferring context: 132B                                                                                 0.0s
 => [internal] load build definition from Dockerfile                                                              0.0s
 => => transferring dockerfile: 644B                                                                              0.0s
 => [internal] load metadata for docker.io/oven/bun:1.2.19-alpine                                                 2.8s
 => [internal] load build context                                                                                 0.0s
 => => transferring context: 2.44kB                                                                               0.0s
 => [builder 1/6] FROM docker.io/oven/bun:1.2.19-alpine@sha256:7dc0e33a62cbc1606d14b07706c3a00ae66e8e9d0e81b8324  0.0s
 => CACHED [builder 2/6] WORKDIR /app                                                                             0.0s
 => ERROR [builder 3/6] COPY ./package.json ./bun.lock ./                                                         0.0s
------
 > [builder 3/6] COPY ./package.json ./bun.lock ./:
------
Dockerfile:4
--------------------
   2 |     WORKDIR /app
   3 |
   4 | >>> COPY ./package.json ./bun.lock ./
   5 |     RUN bun install --frozen-lockfile
   6 |
--------------------
Dockerfile:13
--------------------
  11 |     WORKDIR /app
  12 |
  13 | >>> COPY ./package.json ./bun.lock ./
  14 |     RUN bun install --frozen-lockfile --production --ignore-scripts --no-cache
  15 |
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref 7d5f49e2-a915-4404-a1aa-e6cbaf999c02::7mrgt7qucwkbey4f7hszjkm7v: "/bun.lock": not found
```