### PR TITLE
fix: Remove bun.lock from .dockerignore to fix docker build error

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 node_modules
-bun.lock
 
 .vscode/
 


### PR DESCRIPTION
```
 => ERROR [builder 3/6] COPY ./package.json ./bun.lock ./                                                         0.0s
------
 > [builder 3/6] COPY ./package.json ./bun.lock ./:
------
Dockerfile:4
--------------------
   2 |     WORKDIR /app
   3 |
   4 | >>> COPY ./package.json ./bun.lock ./
   5 |     RUN bun install --frozen-lockfile
   6 |
--------------------
Dockerfile:13
--------------------
  11 |     WORKDIR /app
  12 |
  13 | >>> COPY ./package.json ./bun.lock ./
  14 |     RUN bun install --frozen-lockfile --production --ignore-scripts --no-cache
  15 |
```