### PR TITLE
fix: claude code sub-agent models

### DIFF
--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -26,11 +26,13 @@ import { mapOpenAIStopReasonToAnthropic } from "./utils"
 
 // Payload translation
 
+
+
 export function translateToOpenAI(
   payload: AnthropicMessagesPayload,
 ): ChatCompletionsPayload {
   return {
-    model: payload.model,
+    model: translateModelName(payload.model),
     messages: translateAnthropicMessagesToOpenAI(
       payload.messages,
       payload.system,
@@ -44,6 +46,16 @@ export function translateToOpenAI(
     tools: translateAnthropicToolsToOpenAI(payload.tools),
     tool_choice: translateAnthropicToolChoiceToOpenAI(payload.tool_choice),
   }
+}
+
+function translateModelName(model: string): string {
+  // Subagent requests use a specific model number which Copilot doesn't support
+  if (model.startsWith("claude-sonnet-4-")) {
+    return model.replace(/^claude-sonnet-4-.*/, "claude-sonnet-4")
+  } else if (model.startsWith("claude-opus-")) {
+    return model.replace(/^claude-opus-4-.*/, "claude-opus-4")
+  }
+  return model
 }
 
 function translateAnthropicMessagesToOpenAI(


### PR DESCRIPTION
https://github.com/ericc-ch/copilot-api/issues/79

Claude Code Sub-Agents send an exact model name with the number suffix, which Copilot doesn't work with. 
This change should translate those input model values to remove that suffix. 

**Model name normalization:**

* Added a new function `translateModelName` to normalize model names such as `claude-sonnet-4-*` and `claude-opus-4-*` to their base names (`claude-sonnet-4` and `claude-opus-4`). This prevents unsupported model versions from being sent to Copilot. (`src/routes/messages/non-stream-translation.ts`, [src/routes/messages/non-stream-translation.tsR51-R60](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87R51-R60))
* Updated the `translateToOpenAI` function to use the new `translateModelName` function when setting the `model` field in the translated payload. (`src/routes/messages/non-stream-translation.ts`, [src/routes/messages/non-stream-translation.tsR29-R35](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87R29-R35))