### PR TITLE
Fix multi choices in OpenAI response with different types of content(…

### DIFF
--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -274,8 +274,9 @@ export function translateToAnthropic(
   // Merge content from all choices
   let allTextBlocks: Array<AnthropicTextBlock> = []
   let allToolUseBlocks: Array<AnthropicToolUseBlock> = []
-  let stopReason: "stop" | "length" | "tool_calls" | "content_filter" | null = "stop" // default
-
+  let stopReason: "stop" | "length" | "tool_calls" | "content_filter" | null = null // default
+  stopReason = response.choices[0]?.finish_reason ?? stopReason;
+  
   // Process all choices to extract text and tool use blocks
   for (const choice of response.choices) {
     const textBlocks = getAnthropicTextBlocks(choice.message.content)

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -285,7 +285,7 @@ export function translateToAnthropic(
     allToolUseBlocks.push(...toolUseBlocks)
     
     // Use the finish_reason from the first choice, or prioritize tool_calls
-    if (choice.finish_reason === "tool_calls" || stopReason === "stop") {
+    if (choice.finish_reason === "tool_calls" || (stopReason === "stop" && choice.finish_reason !== null)) {
       stopReason = choice.finish_reason
     }
   }

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -271,9 +271,25 @@ function translateAnthropicToolChoiceToOpenAI(
 export function translateToAnthropic(
   response: ChatCompletionResponse,
 ): AnthropicResponse {
-  const choice = response.choices[0]
-  const textBlocks = getAnthropicTextBlocks(choice.message.content)
-  const toolUseBlocks = getAnthropicToolUseBlocks(choice.message.tool_calls)
+  // Merge content from all choices
+  let allTextBlocks: Array<AnthropicTextBlock> = []
+  let allToolUseBlocks: Array<AnthropicToolUseBlock> = []
+  let stopReason: "stop" | "length" | "tool_calls" | "content_filter" | null = "stop" // default
+
+  // Process all choices to extract text and tool use blocks
+  for (const choice of response.choices) {
+    const textBlocks = getAnthropicTextBlocks(choice.message.content)
+    const toolUseBlocks = getAnthropicToolUseBlocks(choice.message.tool_calls)
+    
+    allTextBlocks.push(...textBlocks)
+    allToolUseBlocks.push(...toolUseBlocks)
+    
+    // Use the finish_reason from the first choice, or prioritize tool_calls
+    if (choice.finish_reason === "tool_calls" || stopReason === "stop") {
+      stopReason = choice.finish_reason
+    }
+  }
+
   // Note: GitHub Copilot doesn't generate thinking blocks, so we don't include them in responses
 
   return {
@@ -281,8 +297,8 @@ export function translateToAnthropic(
     type: "message",
     role: "assistant",
     model: response.model,
-    content: [...textBlocks, ...toolUseBlocks],
-    stop_reason: mapOpenAIStopReasonToAnthropic(choice.finish_reason),
+    content: [...allTextBlocks, ...allToolUseBlocks],
+    stop_reason: mapOpenAIStopReasonToAnthropic(stopReason),
     stop_sequence: null,
     usage: {
       input_tokens: response.usage?.prompt_tokens ?? 0,


### PR DESCRIPTION
…some with text content, some with tool calls), the translation only picked up the text content from the first choice and missing the tool calls from the seconed choice. The code was written by Copilot.