### PR TITLE
 Add configurable header modes (`savings` and `compatible`) for X-Initiator

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,9 +360,8 @@ copilot-api start --header-mode savings
 
 VS Code Copilot extension compatibility:
 
-- **Headers**: Both `X-Initiator` and `X-Interaction-Id`
-- **Logic**: Replicates VS Code extension's behavior(sort of)
-- **Session Management**: UUID-based session tracking
+- **Headers**: `X-Initiator`
+- **Logic**: If last message is user then it is user, otherwise agent
 - **Use case**: Use this when you want to mimic the behavior of the VS Code extension to avoid potential abuse detection. (I am not sure if they do that, but it's better to be cautious.)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -151,17 +151,18 @@ Copilot API now uses a subcommand structure with these main commands:
 
 The following command line options are available for the `start` command:
 
-| Option         | Description                                                                   | Default    | Alias |
-| -------------- | ----------------------------------------------------------------------------- | ---------- | ----- |
-| --port         | Port to listen on                                                             | 4141       | -p    |
-| --verbose      | Enable verbose logging                                                        | false      | -v    |
-| --account-type | Account type to use (individual, business, enterprise)                        | individual | -a    |
-| --manual       | Enable manual request approval                                                | false      | none  |
-| --rate-limit   | Rate limit in seconds between requests                                        | none       | -r    |
-| --wait         | Wait instead of error when rate limit is hit                                  | false      | -w    |
-| --github-token | Provide GitHub token directly (must be generated using the `auth` subcommand) | none       | -g    |
-| --claude-code  | Generate a command to launch Claude Code with Copilot API config              | false      | -c    |
-| --show-token   | Show GitHub and Copilot tokens on fetch and refresh                           | false      | none  |
+| Option         | Description                                                                      | Default    | Alias |
+| -------------- | -------------------------------------------------------------------------------- | ---------- | ----- |
+| --port         | Port to listen on                                                                | 4141       | -p    |
+| --verbose      | Enable verbose logging                                                           | false      | -v    |
+| --account-type | Account type to use (individual, business, enterprise)                           | individual | -a    |
+| --manual       | Enable manual request approval                                                   | false      | none  |
+| --rate-limit   | Rate limit in seconds between requests                                           | none       | -r    |
+| --wait         | Wait instead of error when rate limit is hit                                     | false      | -w    |
+| --github-token | Provide GitHub token directly (must be generated using the `auth` subcommand)    | none       | -g    |
+| --claude-code  | Generate a command to launch Claude Code with Copilot API config                 | false      | -c    |
+| --show-token   | Show GitHub and Copilot tokens on fetch and refresh                              | false      | none  |
+| --header-mode  | Header mode: savings (cost-optimized) or compatible (VS Code extension behavior) | savings    | none  |
 
 ### Auth Command Options
 
@@ -336,3 +337,34 @@ bun run start
   - `--rate-limit <seconds>`: Enforces a minimum time interval between requests. For example, `copilot-api start --rate-limit 30` will ensure there's at least a 30-second gap between requests.
   - `--wait`: Use this with `--rate-limit`. It makes the server wait for the cooldown period to end instead of rejecting the request with an error. This is useful for clients that don't automatically retry on rate limit errors.
 - If you have a GitHub business or enterprise plan account with Copilot, use the `--account-type` flag (e.g., `--account-type business`). See the [official documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-access-to-github-copilot-in-your-organization/managing-github-copilot-access-to-your-organizations-network#configuring-copilot-subscription-based-network-routing-for-your-enterprise-or-organization) for more details.
+
+## Request Header Modes
+
+Copilot API supports two header modes to balance cost optimization with compatibility:
+
+### `savings` Mode (Default)
+
+Maximum cost optimization using current behavior:
+
+- **Headers**: Only `X-Initiator`
+- **Logic**: Set to `agent` when assistant/tool messages present, otherwise `user`
+- **Use case**: Cost-sensitive applications, development, testing
+
+```bash
+copilot-api start
+# or explicitly
+copilot-api start --header-mode savings
+```
+
+### `compatible` Mode
+
+VS Code Copilot extension compatibility:
+
+- **Headers**: Both `X-Initiator` and `X-Interaction-Id`
+- **Logic**: Replicates VS Code extension's behavior(sort of)
+- **Session Management**: UUID-based session tracking
+- **Use case**: Use this when you want to mimic the behavior of the VS Code extension to avoid potential abuse detection. (I am not sure if they do that, but it's better to be cautious.)
+
+```bash
+copilot-api start --header-mode compatible
+```

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The following command line options are available for the `start` command:
 | --github-token | Provide GitHub token directly (must be generated using the `auth` subcommand)    | none       | -g    |
 | --claude-code  | Generate a command to launch Claude Code with Copilot API config                 | false      | -c    |
 | --show-token   | Show GitHub and Copilot tokens on fetch and refresh                              | false      | none  |
-| --header-mode  | Header mode: savings (cost-optimized) or compatible (VS Code extension behavior) | savings    | none  |
+| --header-mode  | Header mode: savings (cost-optimized) or per-user-prompt (mimics VS Code extension) | savings    | none  |
 
 ### Auth Command Options
 
@@ -340,7 +340,7 @@ bun run start
 
 ## Request Header Modes
 
-Copilot API supports two header modes to balance cost optimization with compatibility:
+Copilot API supports two header modes to balance cost optimization with different request patterns:
 
 ### `savings` Mode (Default)
 
@@ -356,14 +356,14 @@ copilot-api start
 copilot-api start --header-mode savings
 ```
 
-### `compatible` Mode
+### `per-user-prompt` Mode
 
-VS Code Copilot extension compatibility:
+VS Code Copilot extension behavior:
 
 - **Headers**: `X-Initiator`
 - **Logic**: If last message is user then it is user, otherwise agent
-- **Use case**: Use this when you want to mimic the behavior of the VS Code extension to avoid potential abuse detection. (I am not sure if they do that, but it's better to be cautious.)
+- **Use case**: Use this when you want to follow the VS Code extension's request pattern to avoid potential abuse detection. (I am not sure if they do that, but it's better to be cautious.)
 
 ```bash
-copilot-api start --header-mode compatible
+copilot-api start --header-mode per-user-prompt
 ```

--- a/src/lib/headers.ts
+++ b/src/lib/headers.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto"
+
+import type { ChatCompletionsPayload } from "~/services/copilot/create-chat-completions"
+
+export type HeaderMode = "savings" | "compatible"
+
+export interface RequestHeaders {
+  "X-Initiator": "user" | "agent"
+  "X-Interaction-Id"?: string
+}
+
+/**
+ * Simple session manager for compatible mode
+ */
+class SessionManager {
+  private sessionId: string = randomUUID()
+
+  newSession(): string {
+    this.sessionId = randomUUID()
+    return this.sessionId
+  }
+
+  getCurrentSession(): string {
+    return this.sessionId
+  }
+}
+
+const sessionManager = new SessionManager()
+
+/**
+ * Generate headers based on mode
+ */
+export function generateSessionHeaders(
+  payload: ChatCompletionsPayload,
+  mode: HeaderMode,
+): RequestHeaders {
+  return mode === "savings" ?
+      {
+        "X-Initiator": getSavingsInitiator(payload),
+      }
+    : {
+        "X-Initiator": getCompatibleInitiator(payload),
+        "X-Interaction-Id": getSessionId(payload),
+      }
+}
+
+/**
+ * Savings mode: default behavior
+ */
+function getSavingsInitiator(
+  payload: ChatCompletionsPayload,
+): "user" | "agent" {
+  return (
+      payload.messages.some((msg) => ["assistant", "tool"].includes(msg.role))
+    ) ?
+      "agent"
+    : "user"
+}
+
+/**
+ * Compatible mode: replicate VS Code extension logic
+ */
+function getCompatibleInitiator(
+  payload: ChatCompletionsPayload,
+): "user" | "agent" {
+  // VS Code: userInitiatedRequest = iterationNumber === 0 && !isContinuation
+  const hasAssistantMessage = payload.messages.some(
+    (msg) => msg.role === "assistant",
+  )
+  const hasToolCalls = payload.messages.some(
+    (msg) => msg.tool_calls && msg.tool_calls.length > 0,
+  )
+  const hasToolMessages = payload.messages.some((msg) => msg.role === "tool")
+
+  const isFirstIteration = !hasAssistantMessage
+  const isContinuation = hasToolCalls || hasToolMessages
+
+  return isFirstIteration && !isContinuation ? "user" : "agent"
+}
+
+/**
+ * Detect if this is the start of a new conversation
+ */
+function isStartOfConversation(payload: ChatCompletionsPayload): boolean {
+  const hasAssistantMessage = payload.messages.some(
+    (msg) => msg.role === "assistant",
+  )
+  return !hasAssistantMessage
+}
+
+/**
+ * Get session ID for compatible mode
+ */
+function getSessionId(payload: ChatCompletionsPayload): string {
+  if (isStartOfConversation(payload)) {
+    return sessionManager.newSession()
+  }
+  return sessionManager.getCurrentSession()
+}

--- a/src/lib/headers.ts
+++ b/src/lib/headers.ts
@@ -1,6 +1,6 @@
 import type { ChatCompletionsPayload } from "~/services/copilot/create-chat-completions"
 
-export type HeaderMode = "savings" | "compatible"
+export type HeaderMode = "savings" | "per-user-prompt"
 
 export interface RequestHeaders {
   "X-Initiator": "user" | "agent"
@@ -18,7 +18,7 @@ export function generateSessionHeaders(
     (payload: ChatCompletionsPayload) => "user" | "agent"
   > = {
     savings: getSavingsInitiator,
-    compatible: getCompatibleInitiator,
+    "per-user-prompt": getPerUserPromptInitiator,
   }
   return {
     "X-Initiator": initiatorMap[mode](payload),
@@ -38,13 +38,15 @@ function isAgentRole(role: string): boolean {
 function getSavingsInitiator(
   payload: ChatCompletionsPayload,
 ): "user" | "agent" {
-  return payload.messages.some((msg) => isAgentRole(msg.role)) ? "agent" : "user"
+  return payload.messages.some((msg) => isAgentRole(msg.role)) ?
+      "agent"
+    : "user"
 }
 
 /**
- * Compatible mode: if last message is user then it is user
+ * Per-user-prompt mode: if last message is user then it is user
  */
-function getCompatibleInitiator(
+function getPerUserPromptInitiator(
   payload: ChatCompletionsPayload,
 ): "user" | "agent" {
   const lastMessage = payload.messages.at(-1)

--- a/src/lib/headers.ts
+++ b/src/lib/headers.ts
@@ -38,9 +38,7 @@ function isAgentRole(role: string): boolean {
 function getSavingsInitiator(
   payload: ChatCompletionsPayload,
 ): "user" | "agent" {
-  return payload.messages.some((msg) => isAgentRole(msg.role)) ?
-      "agent"
-    : "user"
+  return payload.messages.some((msg) => isAgentRole(msg.role)) ? "agent" : "user"
 }
 
 /**

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -15,6 +15,9 @@ export interface State {
   // Rate limiting configuration
   rateLimitSeconds?: number
   lastRequestTimestamp?: number
+
+  // Header mode configuration
+  headerMode: "savings" | "compatible"
 }
 
 export const state: State = {
@@ -22,4 +25,5 @@ export const state: State = {
   manualApprove: false,
   rateLimitWait: false,
   showToken: false,
+  headerMode: "savings",
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -17,7 +17,7 @@ export interface State {
   lastRequestTimestamp?: number
 
   // Header mode configuration
-  headerMode: "savings" | "compatible"
+  headerMode: "savings" | "per-user-prompt"
 }
 
 export const state: State = {

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -31,7 +31,7 @@ export async function handleCompletion(c: Context) {
 
     payload = {
       ...payload,
-      max_tokens: selectedModel?.capabilities.limits.max_output_tokens,
+      max_tokens: selectedModel?.capabilities?.limits?.max_output_tokens,
     }
     consola.debug("Set max_tokens to:", JSON.stringify(payload.max_tokens))
   }

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -313,8 +313,15 @@ export function translateToAnthropic(
     stop_reason: mapOpenAIStopReasonToAnthropic(stopReason),
     stop_sequence: null,
     usage: {
-      input_tokens: response.usage?.prompt_tokens ?? 0,
+      input_tokens:
+        (response.usage?.prompt_tokens ?? 0)
+        - (response.usage?.prompt_tokens_details?.cached_tokens ?? 0),
       output_tokens: response.usage?.completion_tokens ?? 0,
+      ...(response.usage?.prompt_tokens_details?.cached_tokens
+        !== undefined && {
+        cache_read_input_tokens:
+          response.usage.prompt_tokens_details.cached_tokens,
+      }),
     },
   }
 }

--- a/src/routes/messages/route.ts
+++ b/src/routes/messages/route.ts
@@ -2,13 +2,21 @@ import { Hono } from "hono"
 
 import { forwardError } from "~/lib/error"
 
-import { handleCompletion } from "./handler"
+import { handleCompletion, handleCountTokens } from "./handler"
 
 export const messageRoutes = new Hono()
 
 messageRoutes.post("/", async (c) => {
   try {
     return await handleCompletion(c)
+  } catch (error) {
+    return await forwardError(c, error)
+  }
+})
+
+messageRoutes.post("/count_tokens", async (c) => {
+  try {
+    return await handleCountTokens(c)
   } catch (error) {
     return await forwardError(c, error)
   }

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -42,8 +42,15 @@ export function translateChunkToAnthropicEvents(
         stop_reason: null,
         stop_sequence: null,
         usage: {
-          input_tokens: chunk.usage?.prompt_tokens ?? 0,
+          input_tokens:
+            (chunk.usage?.prompt_tokens ?? 0)
+            - (chunk.usage?.prompt_tokens_details?.cached_tokens ?? 0),
           output_tokens: 0, // Will be updated in message_delta when finished
+          ...(chunk.usage?.prompt_tokens_details?.cached_tokens
+            !== undefined && {
+            cache_read_input_tokens:
+              chunk.usage.prompt_tokens_details.cached_tokens,
+          }),
         },
       },
     })
@@ -152,7 +159,9 @@ export function translateChunkToAnthropicEvents(
           stop_sequence: null,
         },
         usage: {
-          input_tokens: chunk.usage?.prompt_tokens ?? 0,
+          input_tokens:
+            (chunk.usage?.prompt_tokens ?? 0)
+            - (chunk.usage?.prompt_tokens_details?.cached_tokens ?? 0),
           output_tokens: chunk.usage?.completion_tokens ?? 0,
           ...(chunk.usage?.prompt_tokens_details?.cached_tokens
             !== undefined && {

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,4 +29,3 @@ server.route("/v1/embeddings", embeddingRoutes)
 
 // Anthropic compatible endpoints
 server.route("/v1/messages", messageRoutes)
-server.post("/v1/messages/count_tokens", (c) => c.json({ input_tokens: 1 }))

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -103,6 +103,9 @@ export interface ChatCompletionResponse {
     prompt_tokens: number
     completion_tokens: number
     total_tokens: number
+    prompt_tokens_details?: {
+      cached_tokens: number
+    }
   }
 }
 

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -26,11 +26,6 @@ export const createChatCompletions = async (
     ...sessionHeaders, // This includes X-Initiator
   }
 
-  // Optional: Add debug logging
-  if (state.headerMode === "compatible") {
-    consola.debug(
-      `Compatible mode headers: X-Initiator=${sessionHeaders["X-Initiator"]}`,
-    )
   // Optional: Add debug logging for all modes
   consola.debug(
     `Headers (${state.headerMode} mode): X-Initiator=${sessionHeaders["X-Initiator"]}`,

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -31,7 +31,10 @@ export const createChatCompletions = async (
     consola.debug(
       `Compatible mode headers: X-Initiator=${sessionHeaders["X-Initiator"]}`,
     )
-  }
+  // Optional: Add debug logging for all modes
+  consola.debug(
+    `Headers (${state.headerMode} mode): X-Initiator=${sessionHeaders["X-Initiator"]}`,
+  )
 
   const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
     method: "POST",

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -23,13 +23,13 @@ export const createChatCompletions = async (
   // Build headers
   const headers: Record<string, string> = {
     ...copilotHeaders(state, enableVision),
-    ...sessionHeaders, // This includes X-Initiator and optionally X-Interaction-Id
+    ...sessionHeaders, // This includes X-Initiator
   }
 
   // Optional: Add debug logging
   if (state.headerMode === "compatible") {
     consola.debug(
-      `Compatible mode headers: X-Initiator=${sessionHeaders["X-Initiator"]}, X-Interaction-Id=${sessionHeaders["X-Interaction-Id"]?.slice(0, 8)}...`,
+      `Compatible mode headers: X-Initiator=${sessionHeaders["X-Initiator"]}`,
     )
   }
 

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -39,7 +39,7 @@ interface ModelCapabilities {
   type: string
 }
 
-interface Model {
+export interface Model {
   capabilities: ModelCapabilities
   id: string
   model_picker_enabled: boolean

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -32,7 +32,7 @@ interface ModelSupports {
 
 interface ModelCapabilities {
   family: string
-  limits: ModelLimits
+  limits?: ModelLimits
   object: string
   supports: ModelSupports
   tokenizer: string
@@ -40,7 +40,7 @@ interface ModelCapabilities {
 }
 
 export interface Model {
-  capabilities: ModelCapabilities
+  capabilities?: ModelCapabilities
   id: string
   model_picker_enabled: boolean
   name: string

--- a/src/start.ts
+++ b/src/start.ts
@@ -29,7 +29,7 @@ interface RunServerOptions {
 }
 
 const formatModelInfo = (model: Model) => {
-  const contextWindow = model.capabilities.limits.max_context_window_tokens
+  const contextWindow = model.capabilities?.limits?.max_context_window_tokens
   const contextStr =
     contextWindow ? ` (${(contextWindow / 1000).toFixed(0)}K tokens)` : ""
   return `- ${model.id}${contextStr}`

--- a/src/start.ts
+++ b/src/start.ts
@@ -6,6 +6,8 @@ import consola from "consola"
 import { serve, type ServerHandler } from "srvx"
 import invariant from "tiny-invariant"
 
+import type { Model } from "./services/copilot/get-models"
+
 import { ensurePaths } from "./lib/paths"
 import { generateEnvScript } from "./lib/shell"
 import { state } from "./lib/state"
@@ -24,6 +26,13 @@ interface RunServerOptions {
   claudeCode: boolean
   showToken: boolean
   headerMode: string
+}
+
+const formatModelInfo = (model: Model) => {
+  const contextWindow = model.capabilities.limits.max_context_window_tokens
+  const contextStr =
+    contextWindow ? ` (${(contextWindow / 1000).toFixed(0)}K tokens)` : ""
+  return `- ${model.id}${contextStr}`
 }
 
 export async function runServer(options: RunServerOptions): Promise<void> {
@@ -68,7 +77,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   await cacheModels()
 
   consola.info(
-    `Available models: \n${state.models?.data.map((model) => `- ${model.id}`).join("\n")}`,
+    `Available models: \n${state.models?.data.map((model) => formatModelInfo(model)).join("\n")}`,
   )
 
   const serverUrl = `http://localhost:${options.port}`

--- a/src/start.ts
+++ b/src/start.ts
@@ -46,7 +46,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   state.headerMode = options.headerMode as "savings" | "compatible"
 
   if (state.headerMode === "compatible") {
-    consola.info("Using compatible mode - full VS Code extension compatibility")
+    consola.info("Using compatible mode - VS Code extension compatibility")
   } else {
     consola.info("Using savings mode - optimized for premium requests savings")
   }

--- a/src/start.ts
+++ b/src/start.ts
@@ -43,10 +43,12 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   state.showToken = options.showToken
 
   // Set header mode
-  state.headerMode = options.headerMode as "savings" | "compatible"
+  state.headerMode = options.headerMode as "savings" | "per-user-prompt"
 
-  if (state.headerMode === "compatible") {
-    consola.info("Using compatible mode - VS Code extension compatibility")
+  if (state.headerMode === "per-user-prompt") {
+    consola.info(
+      "Using per-user-prompt mode - mimics VS Code extension behavior",
+    )
   } else {
     consola.info("Using savings mode - optimized for premium requests savings")
   }
@@ -184,7 +186,7 @@ export const start = defineCommand({
       type: "string",
       default: "savings",
       description:
-        "Header mode: savings (default, cost-optimized) or compatible (VS Code Copilot extension behavior)",
+        "Header mode: savings (default, cost-optimized) or per-user-prompt (VS Code Copilot extension behavior)",
     },
   },
   run({ args }) {

--- a/src/start.ts
+++ b/src/start.ts
@@ -23,6 +23,7 @@ interface RunServerOptions {
   githubToken?: string
   claudeCode: boolean
   showToken: boolean
+  headerMode: string
 }
 
 export async function runServer(options: RunServerOptions): Promise<void> {
@@ -41,10 +42,20 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   state.rateLimitWait = options.rateLimitWait
   state.showToken = options.showToken
 
+  // Set header mode
+  state.headerMode = options.headerMode as "savings" | "compatible"
+
+  if (state.headerMode === "compatible") {
+    consola.info("Using compatible mode - full VS Code extension compatibility")
+  } else {
+    consola.info("Using savings mode - optimized for premium requests savings")
+  }
+
   await ensurePaths()
   await cacheVSCodeVersion()
 
   if (options.githubToken) {
+    // eslint-disable-next-line require-atomic-updates
     state.githubToken = options.githubToken
     consola.info("Using provided GitHub token")
   } else {
@@ -169,6 +180,12 @@ export const start = defineCommand({
       default: false,
       description: "Show GitHub and Copilot tokens on fetch and refresh",
     },
+    "header-mode": {
+      type: "string",
+      default: "savings",
+      description:
+        "Header mode: savings (default, cost-optimized) or compatible (VS Code Copilot extension behavior)",
+    },
   },
   run({ args }) {
     const rateLimitRaw = args["rate-limit"]
@@ -186,6 +203,7 @@ export const start = defineCommand({
       githubToken: args["github-token"],
       claudeCode: args["claude-code"],
       showToken: args["show-token"],
+      headerMode: args["header-mode"],
     })
   },
 })


### PR DESCRIPTION
  ## Summary
  - Add configurable header modes (`savings` and `compatible`) for different use cases

  ## Changes
  - **New CLI option**: `--header-mode` with two modes:
    - `savings` (default): Cost-optimized mode using simple agent/user detection
    - `compatible`: Simplified VS Code extension compatibility mode

  ## Technical Details
  - **Savings mode**: Set to `agent` if any message is assistant/tool, otherwise `user`
  - **Compatible mode**: Set to `user` if last message is user, otherwise `agent`
  - **No breaking changes**: Default behavior maintained with `savings` mode

  ## Test Plan
  - [x] Both header modes generate correct X-Initiator values
  - [x] CLI parameter works as expected
  - [x] Documentation updated

  🤖 Generated with [Claude Code](https://claude.ai/code)