### PR TITLE
Fix hardcoded token counts in streaming responses

### DIFF
--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -160,6 +160,8 @@ export interface AnthropicMessageDeltaEvent {
   usage?: {
     input_tokens?: number
     output_tokens: number
+    cache_creation_input_tokens?: number
+    cache_read_input_tokens?: number
   }
 }
 

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -157,7 +157,10 @@ export interface AnthropicMessageDeltaEvent {
     stop_reason?: AnthropicResponse["stop_reason"]
     stop_sequence?: string | null
   }
-  usage?: { output_tokens: number }
+  usage?: {
+    input_tokens?: number
+    output_tokens: number
+  }
 }
 
 export interface AnthropicMessageStopEvent {

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -154,6 +154,11 @@ export function translateChunkToAnthropicEvents(
         usage: {
           input_tokens: chunk.usage?.prompt_tokens ?? 0,
           output_tokens: chunk.usage?.completion_tokens ?? 0,
+          ...(chunk.usage?.prompt_tokens_details?.cached_tokens
+            !== undefined && {
+            cache_read_input_tokens:
+              chunk.usage.prompt_tokens_details.cached_tokens,
+          }),
         },
       },
       {

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -42,8 +42,8 @@ export function translateChunkToAnthropicEvents(
         stop_reason: null,
         stop_sequence: null,
         usage: {
-          input_tokens: 1,
-          output_tokens: 1, // Anthropic requires this to be > 0
+          input_tokens: chunk.usage?.prompt_tokens ?? 0,
+          output_tokens: 0, // Will be updated in message_delta when finished
         },
       },
     })
@@ -152,7 +152,8 @@ export function translateChunkToAnthropicEvents(
           stop_sequence: null,
         },
         usage: {
-          output_tokens: 1,
+          input_tokens: chunk.usage?.prompt_tokens ?? 0,
+          output_tokens: chunk.usage?.completion_tokens ?? 0,
         },
       },
       {

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -55,6 +55,14 @@ export interface ChatCompletionChunk {
   model: string
   choices: Array<Choice>
   system_fingerprint?: string
+  usage?: {
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+    prompt_tokens_details?: {
+      cached_tokens: number
+    }
+  }
 }
 
 interface Delta {

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -62,6 +62,10 @@ export interface ChatCompletionChunk {
     prompt_tokens_details?: {
       cached_tokens: number
     }
+    completion_tokens_details?: {
+      accepted_prediction_tokens: number
+      rejected_prediction_tokens: number
+    }
   }
 }
 


### PR DESCRIPTION
  ## Summary
  Replace hardcoded 1+1 token values with real GitHub Copilot API usage data in streaming responses
  for agent clients.

  ## Changes
  - Extract actual token counts from `chunk.usage` instead of hardcoding

  ## Impact
  - Agent clients can now properly track token usage through monitoring tools (e.g.,
  claude-code-leaderboard, ccusage, etc.)

  Enables accurate token tracking for agent usage monitoring.

  🤖 Generated with [Claude Code](https://claude.ai/code)