### PR TITLE
fix: map content in handleUserMessage for tool call responses

### DIFF
--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -103,7 +103,7 @@ function handleUserMessage(message: AnthropicUserMessage): Array<Message> {
       newMessages.push({
         role: "tool",
         tool_call_id: block.tool_use_id,
-        content: block.content,
+        content: mapContent(block.content),
       })
     }
 


### PR DESCRIPTION
Fix #95 

There is image type in tool message when calling playwright MCP