### PR TITLE
Add Node.js v20 compatibility support (refs #107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "fetch-event-stream": "^0.1.5",
     "gpt-tokenizer": "^3.0.1",
     "hono": "^4.9.6",
-    "srvx": "^0.8.7",
+    "srvx": "^0.6.0",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Enables Node.js v20 compatibility by downgrading the srvx package to a compatible version, allowing users on Node.js v20 (supported until April 2026) to use this package.

## Changes
- **Package downgrade**: Updated `srvx` from `^0.8.7` to `^0.6.0` for Node.js v20 compatibility
- **Maintained functionality**: All existing server functionality preserved
- **Future-proof**: Ensures compatibility with Node.js v20 LTS (supported until April 2026)

## Test Plan
- [x] Verified package.json syntax and structure
- [x] Confirmed srvx v0.6.0 compatibility with existing codebase
- [x] ESLint and TypeScript validation
- [x] Manual testing on Node.js v20 environment

## Problem Solved
Previously, users on Node.js v20 could not use this package due to srvx dependency incompatibility. This change enables support for the current Node.js LTS version without forcing users to downgrade their Node.js installation.

## Impact
- **Broader compatibility**: Supports Node.js v20 LTS users
- **No breaking changes**: Existing functionality maintained
- **Minimal change**: Only essential dependency adjustment

Closes #107

🤖 Generated with [Claude Code](https://claude.ai/code)