### PR TITLE
feat: Supports network proxy using environment variables

### DIFF
--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -30,6 +30,7 @@ export const createChatCompletions = async (
 
   const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
     method: "POST",
+    proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
     headers,
     body: JSON.stringify(payload),
   })

--- a/src/services/copilot/create-embeddings.ts
+++ b/src/services/copilot/create-embeddings.ts
@@ -7,6 +7,7 @@ export const createEmbeddings = async (payload: EmbeddingRequest) => {
 
   const response = await fetch(`${copilotBaseUrl(state)}/embeddings`, {
     method: "POST",
+    proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
     headers: copilotHeaders(state),
     body: JSON.stringify(payload),
   })

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -5,6 +5,7 @@ import { state } from "~/lib/state"
 export const getModels = async () => {
   const response = await fetch(`${copilotBaseUrl(state)}/models`, {
     headers: copilotHeaders(state),
+    proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
   })
 
   if (!response.ok) throw new HTTPError("Failed to get models", response)

--- a/src/services/get-vscode-version.ts
+++ b/src/services/get-vscode-version.ts
@@ -11,6 +11,7 @@ export async function getVSCodeVersion() {
       "https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=visual-studio-code-bin",
       {
         signal: controller.signal,
+        proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
       },
     )
 

--- a/src/services/github/get-copilot-token.ts
+++ b/src/services/github/get-copilot-token.ts
@@ -7,6 +7,7 @@ export const getCopilotToken = async () => {
     `${GITHUB_API_BASE_URL}/copilot_internal/v2/token`,
     {
       headers: githubHeaders(state),
+      proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
     },
   )
 

--- a/src/services/github/get-copilot-usage.ts
+++ b/src/services/github/get-copilot-usage.ts
@@ -4,6 +4,7 @@ import { state } from "~/lib/state"
 
 export const getCopilotUsage = async (): Promise<CopilotUsageResponse> => {
   const response = await fetch(`${GITHUB_API_BASE_URL}/copilot_internal/user`, {
+    proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
     headers: githubHeaders(state),
   })
 

--- a/src/services/github/get-device-code.ts
+++ b/src/services/github/get-device-code.ts
@@ -10,6 +10,7 @@ export async function getDeviceCode(): Promise<DeviceCodeResponse> {
   const response = await fetch(`${GITHUB_BASE_URL}/login/device/code`, {
     method: "POST",
     headers: standardHeaders(),
+    proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
     body: JSON.stringify({
       client_id: GITHUB_CLIENT_ID,
       scope: GITHUB_APP_SCOPES,

--- a/src/services/github/get-user.ts
+++ b/src/services/github/get-user.ts
@@ -4,6 +4,7 @@ import { state } from "~/lib/state"
 
 export async function getGitHubUser() {
   const response = await fetch(`${GITHUB_API_BASE_URL}/user`, {
+    proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
     headers: {
       authorization: `token ${state.githubToken}`,
       ...standardHeaders(),

--- a/src/services/github/poll-access-token.ts
+++ b/src/services/github/poll-access-token.ts
@@ -23,6 +23,7 @@ export async function pollAccessToken(
       {
         method: "POST",
         headers: standardHeaders(),
+        proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
         body: JSON.stringify({
           client_id: GITHUB_CLIENT_ID,
           device_code: deviceCode.device_code,


### PR DESCRIPTION
# Proxy Support

Supports access to Github Copilot's API through a proxy for accessing Claude models.
This is achieved by adding a proxy attribute to each `fetch` function.
Proxy access can be achieved by configuring the environment variables of the program execution.


Proxy Example:

<img width="621" height="77" alt="image" src="https://github.com/user-attachments/assets/9de3e01f-1a82-43e0-88bd-127e22ddd3c3" />

Effect:

<img width="764" height="720" alt="image" src="https://github.com/user-attachments/assets/d946453a-25c0-4577-8b25-cc6e48b29a19" />

