### PR TITLE
WIP: Support GitHub's Responses Endpoint

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -1,0 +1,41 @@
+import type { Context } from "hono"
+
+import consola from "consola"
+import { streamSSE, SSEMessage } from "hono/streaming"
+
+import { awaitApproval } from "~/lib/approval"
+import { checkRateLimit } from "~/lib/rate-limit"
+import { state } from "~/lib/state"
+import { createResponses } from "~/services/copilot/create-responses"
+
+export async function handleResponse(c: Context) {
+  await checkRateLimit(state)
+
+  const payload = await c.req.json()
+  consola.debug("Request payload:", JSON.stringify(payload))
+
+  if (state.manualApprove) await awaitApproval()
+
+  const response = await createResponses(payload)
+
+  if (isNonStreaming(response)) {
+    consola.debug("Non-streaming response:", JSON.stringify(response))
+    return c.json(response)
+  }
+
+  consola.debug("Streaming response")
+  return streamSSE(c, async (stream) => {
+    for await (const chunk of response) {
+      consola.debug("Streaming chunk:", JSON.stringify(chunk))
+      await stream.writeSSE(chunk as SSEMessage)
+    }
+  })
+}
+
+function isNonStreaming(response) { return false; }
+// function isNonStreaming(response: any) {
+//   return !response || typeof response[Symbol.asyncIterator] !== 'function';
+// }
+// const isNonStreaming = (
+//   response: Awaited<ReturnType<typeof createChatCompletions>>,
+// ): response is ResponsesResponse => Object.hasOwn(response, )

--- a/src/routes/responses/route.ts
+++ b/src/routes/responses/route.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono"
+
+import { forwardError } from "~/lib/error"
+
+import { handleResponse } from "./handler"
+
+export const responsesRoutes = new Hono()
+
+responsesRoutes.post("/", async (c) => {
+  try {
+    return await handleResponse(c)
+  } catch (error) {
+    return await forwardError(c, error)
+  }
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { completionRoutes } from "./routes/chat-completions/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
 import { modelRoutes } from "./routes/models/route"
+import { responsesRoutes } from "./routes/responses/route"
 import { tokenRoute } from "./routes/token/route"
 import { usageRoute } from "./routes/usage/route"
 
@@ -17,6 +18,7 @@ server.use(cors())
 server.get("/", (c) => c.text("Server running"))
 
 server.route("/chat/completions", completionRoutes)
+server.route("/responses", responsesRoutes)
 server.route("/models", modelRoutes)
 server.route("/embeddings", embeddingRoutes)
 server.route("/usage", usageRoute)
@@ -26,6 +28,7 @@ server.route("/token", tokenRoute)
 server.route("/v1/chat/completions", completionRoutes)
 server.route("/v1/models", modelRoutes)
 server.route("/v1/embeddings", embeddingRoutes)
+server.route("/v1/responses", responsesRoutes)
 
 // Anthropic compatible endpoints
 server.route("/v1/messages", messageRoutes)

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1,0 +1,113 @@
+import consola from "consola"
+import { events } from "fetch-event-stream"
+
+import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
+import { HTTPError } from "~/lib/error"
+import { state } from "~/lib/state"
+
+export const createResponses = async (
+  // payload: ResponsesPayload,
+  payload
+) => {
+  if (!state.copilotToken) throw new Error("Copilot token not found")
+
+  const enableVision = false;  // FIXME
+
+  const input = Array.isArray(payload.input) ? payload.input : [payload.input];
+  const isAgentCall = input.some((msg) => {
+    if (msg.role == "assistant") return true;
+    if (msg.type == "function_call_output") return true;
+    return false;
+  });
+
+  const headers: Record<string, string> = {
+    ...copilotHeaders(state, enableVision),
+    "X-Initiator": isAgentCall ? "agent" : "user",
+  }
+
+  console.log("REQUEST:", payload)
+  const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  })
+  console.log("RESPONSE:", response)
+  // const responseJson = await response.json()
+  // console.log("RESPONSE JSON:", responseJson)
+  const responseBody = response.body
+  console.log("RESPONSE BODY:", responseBody)
+
+  if (!response.ok) {
+    consola.error("Failed to create responses", response)
+    throw new HTTPError("Failed to create responses", response)
+  }
+
+  if (payload.stream) {
+    return events(response)
+  }
+
+  return (await response.json()) // as ResponsesResponse
+}
+
+// export interface ResponsesChunk {
+//   //
+// }
+
+// export interface ResponsesResponse {
+//   background: boolean
+//   conversation: {
+//     id: string
+//   }
+//   created_at: number
+//   error: {
+//     code: string
+//     message: string
+//   }
+//   id: string
+//   incomplete_details: {
+//     reason: string
+//   }
+//   instructions: string | InputItemList
+//   max_output_tokens: number
+//   max_tool_calls: number
+//   // metadata: //map
+//   model: string
+//   object: "response"
+//   output: Array<OutputMessage | FileSearchToolCall | WebSearchToolCall | ComputerToolCall | Reasoning | ImageGenerationCall | CodeInterpreterToolCall | LocalShellCall | McpToolCall | McpListTools | McpApprovalRequest | CustomToolCall>
+//   parallel_tool_calls: boolean
+//   previous_response_id: string
+//   prompt: {
+//     id: string
+//     // variables: //map
+//     version: string
+//   }
+//   prompt_cache_key: string
+//   reasoning: {
+//     effort: string
+//     summary: string
+//   }
+//   safety_identifier: string
+//   service_tier: string
+//   status: string
+//   temperature: number
+//   text: {
+//     // format: Text | JsonSchema | JsonObject
+//     verbosity: string
+//   }
+//   tool_choice: string | ToolChoice
+//   tools: Array<FunctionTool | FileSearchTool | ComputerUsePreviewTool | WebSearchTool | McpTool | CodeInterpreterTool | ImageGenerationTool | LocalShellTool | CustomTool | WebSearchPreviewTool>
+//   top_logprobs: number
+//   top_p: number
+//   truncation: string
+//   usage: {
+//     input_tokens: number
+//     input_tokens_details: {
+//       cached_tokens: number
+//     }
+//     output_tokens: number
+//     output_tokens_details: {
+//       reasoning_tokens: number
+//     }
+//     total_tokens: number
+//   }
+// }


### PR DESCRIPTION
This enables access to gpt-5-codex, with the following codex-cli config.toml. It works but needs polishing. TODO:

- [ ] isNonStreaming
- [ ] max_tokens
- [ ] type definitions
- [ ] testing

Config:

```toml
model_provider = "copilot-api"
model = "gpt-5-codex"
model_reasoning_effort = "high"

[model_providers.copilot-api]
name = "GitHub Copilot API"
base_url = "http://localhost:4141/v1"
wire_api = "responses"
```

Re: max_tokens, I'm not sure of the purpose of this code from chat-completions/handler.ts:

```typescript
  if (isNullish(payload.max_tokens)) {
    const selectedModel = state.models?.data.find(
      (model) => model.id === payload.model,
    )

    payload = {
      ...payload,
      max_tokens: selectedModel?.capabilities.limits.max_output_tokens,
    }
    consola.debug("Set max_tokens to:", JSON.stringify(payload.max_tokens))
  }
```

Re: testing, the model is currently overloaded via GitHub so it's mostly unusable at the moment:
```
⚠️ stream error: We're currently experiencing high demand, which may cause temporary errors.; retrying 1/5 in 182ms…
⚠️ stream error: stream disconnected before completion: Transport error: error decoding response body; retrying 1/5 in 216ms…
⚠️ stream error: exceeded retry limit, last status: 429 Too Many Requests; retrying 1/5 in 214ms…
```

Another thing: Codex is unable to do web searches (`--search`), but it looks like a github limitation:

```
 ERROR  HTTP error: { error:
   { message: 'The requested tool web_search is not supported.',
     code: 'unsupported_value',
     param: 'tools',
     type: 'invalid_request_error' } }
```
