### PR TITLE
feat: Support specifying multiple apiKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The following command line options are available for the `start` command:
 | --claude-code  | Generate a command to launch Claude Code with Copilot API config              | false      | -c    |
 | --show-token   | Show GitHub and Copilot tokens on fetch and refresh                           | false      | none  |
 | --proxy-env    | Initialize proxy from environment variables                                   | false      | none  |
+| --api-key      | API keys for authentication. Can be specified multiple times                  | none       | none  |
 
 ### Auth Command Options
 
@@ -209,6 +210,41 @@ New endpoints for monitoring your Copilot usage and quotas.
 | `GET /usage` | `GET`  | Get detailed Copilot usage statistics and quota information. |
 | `GET /token` | `GET`  | Get the current Copilot token being used by the API.         |
 
+## API Key Authentication
+
+The proxy supports API key authentication to restrict access to the endpoints. When API keys are configured, all API endpoints require authentication.
+
+### Authentication Methods
+
+The proxy supports both OpenAI and Anthropic authentication formats:
+
+- **OpenAI format**: Include the API key in the `Authorization` header with `Bearer` prefix:
+  ```bash
+  curl -H "Authorization: Bearer your_api_key_here" http://localhost:4141/v1/models
+  ```
+
+- **Anthropic format**: Include the API key in the `x-api-key` header:
+  ```bash
+  curl -H "x-api-key: your_api_key_here" http://localhost:4141/v1/messages
+  ```
+
+### Configuration
+
+Use the `--api-key` flag to enable API key authentication. You can specify multiple keys for different clients:
+
+```bash
+# Single API key
+npx copilot-api@latest start --api-key your_secret_key
+
+# Multiple API keys  
+npx copilot-api@latest start --api-key key1 --api-key key2 --api-key key3
+```
+
+When API keys are configured:
+- All API endpoints (`/v1/chat/completions`, `/v1/models`, `/v1/embeddings`, `/v1/messages`, `/usage`, `/token`) require authentication
+- Requests without valid API keys will receive a 401 Unauthorized response
+- The root endpoint `/` remains accessible without authentication
+
 ## Example Usage
 
 Using with npx:
@@ -237,6 +273,12 @@ npx copilot-api@latest start --rate-limit 30 --wait
 
 # Provide GitHub token directly
 npx copilot-api@latest start --github-token ghp_YOUR_TOKEN_HERE
+
+# Enable API key authentication with a single key
+npx copilot-api@latest start --api-key your_secret_key_here
+
+# Enable API key authentication with multiple keys
+npx copilot-api@latest start --api-key key1 --api-key key2 --api-key key3
 
 # Run only the auth flow
 npx copilot-api@latest auth

--- a/src/lib/api-key-auth.ts
+++ b/src/lib/api-key-auth.ts
@@ -21,6 +21,12 @@ function extractApiKey(c: Context): string | undefined {
     return anthropicKey
   }
 
+  // Fallback: query parameter, for extra compatibility of `/usage` or `/token` route
+  const queryKey = c.req.query("apiKey")
+  if (queryKey) {
+    return queryKey
+  }
+
   return undefined
 }
 

--- a/src/lib/api-key-auth.ts
+++ b/src/lib/api-key-auth.ts
@@ -1,0 +1,59 @@
+import type { Context, MiddlewareHandler } from "hono"
+
+import { HTTPException } from "hono/http-exception"
+
+import { state } from "./state"
+
+/**
+ * Extract API key from request headers
+ * Supports both OpenAI format (Authorization: Bearer token) and Anthropic format (x-api-key: token)
+ */
+function extractApiKey(c: Context): string | undefined {
+  // OpenAI format: Authorization header with Bearer prefix
+  const authHeader = c.req.header("authorization")
+  if (authHeader?.startsWith("Bearer ")) {
+    return authHeader.slice(7) // Remove 'Bearer ' prefix
+  }
+
+  // Anthropic format: x-api-key header
+  const anthropicKey = c.req.header("x-api-key")
+  if (anthropicKey) {
+    return anthropicKey
+  }
+
+  return undefined
+}
+
+/**
+ * API key authentication middleware
+ * Validates that the request contains a valid API key if API keys are configured
+ */
+export const apiKeyAuthMiddleware: MiddlewareHandler = async (c, next) => {
+  // If no API keys are configured, skip authentication
+  if (!state.apiKeys || state.apiKeys.length === 0) {
+    await next()
+    return
+  }
+
+  const providedKey = extractApiKey(c)
+
+  // If no API key is provided, return 401
+  if (!providedKey) {
+    throw new HTTPException(401, {
+      message:
+        "API key required. Please provide a valid API key in the Authorization header (Bearer token) or x-api-key header.",
+    })
+  }
+
+  // Check if the provided key matches any of the configured keys
+  const isValidKey = state.apiKeys.includes(providedKey)
+
+  if (!isValidKey) {
+    throw new HTTPException(401, {
+      message: "Invalid API key. Please provide a valid API key.",
+    })
+  }
+
+  // Key is valid, continue with the request
+  await next()
+}

--- a/src/lib/api-key-auth.ts
+++ b/src/lib/api-key-auth.ts
@@ -22,12 +22,6 @@ function extractApiKey(c: Context): string | undefined {
     return anthropicKey
   }
 
-  // Fallback: query parameter, for extra compatibility of `/usage` or `/token` route
-  const queryKey = c.req.query("apiKey")
-  if (queryKey) {
-    return queryKey
-  }
-
   return undefined
 }
 
@@ -47,8 +41,7 @@ export const apiKeyAuthMiddleware: MiddlewareHandler = async (c, next) => {
   // If no API key is provided, return 401
   if (!providedKey) {
     throw new HTTPException(401, {
-      message:
-        "API key required. Please provide a valid API key in the Authorization header (Bearer token) or x-api-key header.",
+      message: "Missing API key",
     })
   }
 
@@ -59,7 +52,7 @@ export const apiKeyAuthMiddleware: MiddlewareHandler = async (c, next) => {
 
   if (!isValidKey) {
     throw new HTTPException(401, {
-      message: "Invalid API key. Please provide a valid API key.",
+      message: "Invalid API key",
     })
   }
 

--- a/src/lib/api-key-auth.ts
+++ b/src/lib/api-key-auth.ts
@@ -3,6 +3,7 @@ import type { Context, MiddlewareHandler } from "hono"
 import { HTTPException } from "hono/http-exception"
 
 import { state } from "./state"
+import { constantTimeEqual } from "./utils"
 
 /**
  * Extract API key from request headers
@@ -52,7 +53,9 @@ export const apiKeyAuthMiddleware: MiddlewareHandler = async (c, next) => {
   }
 
   // Check if the provided key matches any of the configured keys
-  const isValidKey = state.apiKeys.includes(providedKey)
+  const isValidKey = state.apiKeys.some((key) =>
+    constantTimeEqual(key, providedKey),
+  )
 
   if (!isValidKey) {
     throw new HTTPException(401, {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -15,6 +15,9 @@ export interface State {
   // Rate limiting configuration
   rateLimitSeconds?: number
   lastRequestTimestamp?: number
+
+  // API key validation
+  apiKeys?: Array<string>
 }
 
 export const state: State = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,3 +24,14 @@ export const cacheVSCodeVersion = async () => {
 
   consola.info(`Using VSCode version: ${response}`)
 }
+
+export const constantTimeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) {
+    return false
+  }
+  let result = 0
+  for (let i = 0; i < a.length; i++) {
+    result |= (a.codePointAt(i) ?? 0) ^ (b.codePointAt(i) ?? 0)
+  }
+  return result === 0
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 
+import { apiKeyAuthMiddleware } from "./lib/api-key-auth"
 import { completionRoutes } from "./routes/chat-completions/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
@@ -13,6 +14,16 @@ export const server = new Hono()
 
 server.use(logger())
 server.use(cors())
+
+server.use("/chat/completions", apiKeyAuthMiddleware)
+server.use("/models", apiKeyAuthMiddleware)
+server.use("/embeddings", apiKeyAuthMiddleware)
+server.use("/usage", apiKeyAuthMiddleware)
+server.use("/token", apiKeyAuthMiddleware)
+server.use("/v1/chat/completions", apiKeyAuthMiddleware)
+server.use("/v1/models", apiKeyAuthMiddleware)
+server.use("/v1/embeddings", apiKeyAuthMiddleware)
+server.use("/v1/messages", apiKeyAuthMiddleware)
 
 server.get("/", (c) => c.text("Server running"))
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -25,6 +25,7 @@ interface RunServerOptions {
   claudeCode: boolean
   showToken: boolean
   proxyEnv: boolean
+  apiKeys?: Array<string>
 }
 
 export async function runServer(options: RunServerOptions): Promise<void> {
@@ -46,6 +47,13 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   state.rateLimitSeconds = options.rateLimit
   state.rateLimitWait = options.rateLimitWait
   state.showToken = options.showToken
+  state.apiKeys = options.apiKeys
+
+  if (state.apiKeys && state.apiKeys.length > 0) {
+    consola.info(
+      `API key authentication enabled with ${state.apiKeys.length} key(s)`,
+    )
+  }
 
   await ensurePaths()
   await cacheVSCodeVersion()
@@ -184,12 +192,23 @@ export const start = defineCommand({
       default: false,
       description: "Initialize proxy from environment variables",
     },
+    "api-key": {
+      type: "string",
+      description: "API keys for authentication",
+    },
   },
   run({ args }) {
     const rateLimitRaw = args["rate-limit"]
     const rateLimit =
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       rateLimitRaw === undefined ? undefined : Number.parseInt(rateLimitRaw, 10)
+
+    // Handle multiple API keys - citty may pass a string or array
+    const apiKeyRaw = args["api-key"]
+    let apiKeys: Array<string> | undefined
+    if (apiKeyRaw) {
+      apiKeys = Array.isArray(apiKeyRaw) ? apiKeyRaw : [apiKeyRaw]
+    }
 
     return runServer({
       port: Number.parseInt(args.port, 10),
@@ -202,6 +221,7 @@ export const start = defineCommand({
       claudeCode: args["claude-code"],
       showToken: args["show-token"],
       proxyEnv: args["proxy-env"],
+      apiKeys,
     })
   },
 })


### PR DESCRIPTION
# Add API Key Authentication Support

## 🎯 Overview

This pull request adds comprehensive API key authentication support to the Copilot API proxy, allowing administrators to secure their proxy endpoints with configurable API keys.

## ✨ Features

### 🔐 Flexible Authentication
- **Multiple Authentication Formats**: Supports both OpenAI (`Authorization: Bearer <token>`) and Anthropic (`x-api-key: <token>`) authentication formats
- **Multiple API Keys**: Configure multiple API keys to support different clients or environments
- **Selective Protection**: Only API endpoints require authentication; the root endpoint remains publicly accessible

### 🛠️ Configuration
- **CLI Integration**: New `--api-key` flag supports multiple values for easy configuration
- **Runtime Configuration**: API keys are stored in application state and can be specified at startup

### 🔒 Security Features
- **401 Unauthorized**: Proper error responses for missing or invalid API keys
- **Comprehensive Coverage**: All API endpoints (`/v1/chat/completions`, `/v1/models`, `/v1/embeddings`, `/v1/messages`, `/usage`, `/token`) are protected when API keys are configured

## 📝 Changes

### New Files
- **api-key-auth.ts**: Core authentication middleware with support for both OpenAI and Anthropic authentication formats

### Modified Files
- **state.ts**: Added `apiKeys` field to application state interface
- **server.ts**: Integrated authentication middleware for all protected endpoints
- **start.ts**: Added CLI option handling and initialization logic for API keys
- **README.md**: Comprehensive documentation including configuration examples and usage patterns

## 🚀 Usage Examples

### Single API Key
```bash
npx copilot-api@latest start --api-key your_secret_key
```

### Multiple API Keys
```bash
npx copilot-api@latest start --api-key key1 --api-key key2 --api-key key3
```

### Authentication Requests
```bash
# OpenAI format
curl -H "Authorization: Bearer your_api_key_here" http://localhost:4141/v1/models

# Anthropic format  
curl -H "x-api-key: your_api_key_here" http://localhost:4141/v1/messages
```

## 💡 Implementation Notes

- **Backward Compatibility**: When no API keys are configured, the proxy behaves exactly as before
- **Performance**: Lightweight middleware with minimal overhead
- **Extensibility**: Clean architecture allows for easy addition of more authentication methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API key authentication with a new --api-key option supporting single or multiple keys
  * Accepts keys via Bearer token or x-api-key header
  * When keys are configured, most endpoints require authentication; root endpoint remains public
  * Invalid or missing keys return 401 responses

* **Documentation**
  * Added API Key Authentication docs and updated usage/admin examples showing single and multiple key configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->