### PR TITLE
feature about chat completions reasoning, support gemini-3-pro thinking and support claude model enable thinking and interleaved thinking

### DIFF
--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -14,9 +14,8 @@ const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 const API_VERSION = "2025-10-01"
 
 export const copilotBaseUrl = (state: State) =>
-  state.accountType === "individual" ?
-    "https://api.githubcopilot.com"
-  : `https://api.${state.accountType}.githubcopilot.com`
+  `https://api.${state.accountType}.githubcopilot.com`
+
 export const copilotHeaders = (state: State, vision: boolean = false) => {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${state.copilotToken}`,
@@ -25,7 +24,7 @@ export const copilotHeaders = (state: State, vision: boolean = false) => {
     "editor-version": `vscode/${state.vsCodeVersion}`,
     "editor-plugin-version": EDITOR_PLUGIN_VERSION,
     "user-agent": USER_AGENT,
-    "openai-intent": "conversation-panel",
+    "openai-intent": "conversation-agent",
     "x-github-api-version": API_VERSION,
     "x-request-id": randomUUID(),
     "x-vscode-user-agent-library-version": "electron-fetch",

--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -7,7 +7,7 @@ export const standardHeaders = () => ({
   accept: "application/json",
 })
 
-const COPILOT_VERSION = "0.33.5"
+const COPILOT_VERSION = "0.35.0"
 const EDITOR_PLUGIN_VERSION = `copilot-chat/${COPILOT_VERSION}`
 const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 

--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -7,11 +7,11 @@ export const standardHeaders = () => ({
   accept: "application/json",
 })
 
-const COPILOT_VERSION = "0.26.7"
+const COPILOT_VERSION = "0.33.5"
 const EDITOR_PLUGIN_VERSION = `copilot-chat/${COPILOT_VERSION}`
 const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 
-const API_VERSION = "2025-04-01"
+const API_VERSION = "2025-10-01"
 
 export const copilotBaseUrl = (state: State) =>
   state.accountType === "individual" ?

--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -14,8 +14,9 @@ const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 const API_VERSION = "2025-10-01"
 
 export const copilotBaseUrl = (state: State) =>
-  `https://api.${state.accountType}.githubcopilot.com`
-
+  state.accountType === "individual" ?
+    "https://api.githubcopilot.com"
+  : `https://api.${state.accountType}.githubcopilot.com`
 export const copilotHeaders = (state: State, vision: boolean = false) => {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${state.copilotToken}`,

--- a/src/lib/tokenizer.ts
+++ b/src/lib/tokenizer.ts
@@ -73,6 +73,9 @@ const calculateMessageTokens = (
   const tokensPerName = 1
   let tokens = tokensPerMessage
   for (const [key, value] of Object.entries(message)) {
+    if (key === "reasoning_opaque") {
+      continue
+    }
     if (typeof value === "string") {
       tokens += encoder.encode(value).length
     }

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -56,6 +56,7 @@ export interface AnthropicToolUseBlock {
 export interface AnthropicThinkingBlock {
   type: "thinking"
   thinking: string
+  signature: string
 }
 
 export type AnthropicUserContentBlock =

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -196,6 +196,7 @@ export interface AnthropicStreamState {
   messageStartSent: boolean
   contentBlockIndex: number
   contentBlockOpen: boolean
+  thinkingBlockOpen: boolean
   toolCalls: {
     [openAIToolIndex: number]: {
       id: string

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -60,6 +60,7 @@ export async function handleCompletion(c: Context) {
       contentBlockIndex: 0,
       contentBlockOpen: false,
       toolCalls: {},
+      thinkingBlockOpen: false,
     }
 
     for await (const rawEvent of response) {

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -65,7 +65,11 @@ function getThinkingBudget(
       (model.capabilities.limits.max_output_tokens ?? 0) - 1,
     )
     if (maxThinkingBudget > 0 && thinking.budget_tokens !== undefined) {
-      return Math.min(thinking.budget_tokens, maxThinkingBudget)
+      const budgetTokens = Math.min(thinking.budget_tokens, maxThinkingBudget)
+      return Math.max(
+        budgetTokens,
+        model.capabilities.supports.min_thinking_budget ?? 1024,
+      )
     }
   }
   return undefined
@@ -322,13 +326,13 @@ export function translateToAnthropic(
   // Process all choices to extract text and tool use blocks
   for (const choice of response.choices) {
     const textBlocks = getAnthropicTextBlocks(choice.message.content)
-    const thingBlocks = getAnthropicThinkBlocks(
+    const thinkBlocks = getAnthropicThinkBlocks(
       choice.message.reasoning_text,
       choice.message.reasoning_opaque,
     )
     const toolUseBlocks = getAnthropicToolUseBlocks(choice.message.tool_calls)
 
-    assistantContentBlocks.push(...thingBlocks, ...textBlocks, ...toolUseBlocks)
+    assistantContentBlocks.push(...thinkBlocks, ...textBlocks, ...toolUseBlocks)
 
     // Use the finish_reason from the first choice, or prioritize tool_calls
     if (choice.finish_reason === "tool_calls" || stopReason === "stop") {

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -287,7 +287,7 @@ export function translateToAnthropic(
     )
     const toolUseBlocks = getAnthropicToolUseBlocks(choice.message.tool_calls)
 
-    assistantContentBlocks.push(...textBlocks, ...thingBlocks, ...toolUseBlocks)
+    assistantContentBlocks.push(...thingBlocks, ...textBlocks, ...toolUseBlocks)
 
     // Use the finish_reason from the first choice, or prioritize tool_calls
     if (choice.finish_reason === "tool_calls" || stopReason === "stop") {
@@ -320,7 +320,7 @@ export function translateToAnthropic(
 function getAnthropicTextBlocks(
   messageContent: Message["content"],
 ): Array<AnthropicTextBlock> {
-  if (typeof messageContent === "string") {
+  if (typeof messageContent === "string" && messageContent.length > 0) {
     return [{ type: "text", text: messageContent }]
   }
 
@@ -337,16 +337,16 @@ function getAnthropicThinkBlocks(
   reasoningText: string | null | undefined,
   reasoningOpaque: string | null | undefined,
 ): Array<AnthropicThinkingBlock> {
-  if (reasoningText) {
+  if (reasoningText && reasoningText.length > 0) {
     return [
       {
         type: "thinking",
         thinking: reasoningText,
-        signature: "",
+        signature: reasoningOpaque || "",
       },
     ]
   }
-  if (reasoningOpaque) {
+  if (reasoningOpaque && reasoningOpaque.length > 0) {
     return [
       {
         type: "thinking",

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -139,25 +139,26 @@ function handleAssistantMessage(
     (block): block is AnthropicToolUseBlock => block.type === "tool_use",
   )
 
-  const textBlocks = message.content.filter(
-    (block): block is AnthropicTextBlock => block.type === "text",
-  )
-
   const thinkingBlocks = message.content.filter(
     (block): block is AnthropicThinkingBlock => block.type === "thinking",
   )
 
-  // Combine text and thinking blocks, as OpenAI doesn't have separate thinking blocks
-  const allTextContent = [
-    ...textBlocks.map((b) => b.text),
-    ...thinkingBlocks.map((b) => b.thinking),
-  ].join("\n\n")
+  const allThinkingContent = thinkingBlocks
+    .filter((b) => b.thinking && b.thinking.length > 0)
+    .map((b) => b.thinking)
+    .join("\n\n")
+
+  const signature = thinkingBlocks.find(
+    (b) => b.signature && b.signature.length > 0,
+  )?.signature
 
   return toolUseBlocks.length > 0 ?
       [
         {
           role: "assistant",
-          content: allTextContent || null,
+          content: mapContent(message.content),
+          reasoning_text: allThinkingContent,
+          reasoning_opaque: signature,
           tool_calls: toolUseBlocks.map((toolUse) => ({
             id: toolUse.id,
             type: "function",
@@ -172,6 +173,8 @@ function handleAssistantMessage(
         {
           role: "assistant",
           content: mapContent(message.content),
+          reasoning_text: allThinkingContent,
+          reasoning_opaque: signature,
         },
       ]
 }
@@ -191,11 +194,8 @@ function mapContent(
   const hasImage = content.some((block) => block.type === "image")
   if (!hasImage) {
     return content
-      .filter(
-        (block): block is AnthropicTextBlock | AnthropicThinkingBlock =>
-          block.type === "text" || block.type === "thinking",
-      )
-      .map((block) => (block.type === "text" ? block.text : block.thinking))
+      .filter((block): block is AnthropicTextBlock => block.type === "text")
+      .map((block) => block.text)
       .join("\n\n")
   }
 
@@ -204,12 +204,6 @@ function mapContent(
     switch (block.type) {
       case "text": {
         contentParts.push({ type: "text", text: block.text })
-
-        break
-      }
-      case "thinking": {
-        contentParts.push({ type: "text", text: block.thinking })
-
         break
       }
       case "image": {
@@ -219,7 +213,6 @@ function mapContent(
             url: `data:${block.source.media_type};base64,${block.source.data}`,
           },
         })
-
         break
       }
       // No default
@@ -282,19 +275,19 @@ export function translateToAnthropic(
   response: ChatCompletionResponse,
 ): AnthropicResponse {
   // Merge content from all choices
-  const allTextBlocks: Array<AnthropicTextBlock> = []
-  const allToolUseBlocks: Array<AnthropicToolUseBlock> = []
-  let stopReason: "stop" | "length" | "tool_calls" | "content_filter" | null =
-    null // default
-  stopReason = response.choices[0]?.finish_reason ?? stopReason
+  const assistantContentBlocks: Array<AnthropicAssistantContentBlock> = []
+  let stopReason = response.choices[0]?.finish_reason ?? null
 
   // Process all choices to extract text and tool use blocks
   for (const choice of response.choices) {
     const textBlocks = getAnthropicTextBlocks(choice.message.content)
+    const thingBlocks = getAnthropicThinkBlocks(
+      choice.message.reasoning_text,
+      choice.message.reasoning_opaque,
+    )
     const toolUseBlocks = getAnthropicToolUseBlocks(choice.message.tool_calls)
 
-    allTextBlocks.push(...textBlocks)
-    allToolUseBlocks.push(...toolUseBlocks)
+    assistantContentBlocks.push(...textBlocks, ...thingBlocks, ...toolUseBlocks)
 
     // Use the finish_reason from the first choice, or prioritize tool_calls
     if (choice.finish_reason === "tool_calls" || stopReason === "stop") {
@@ -302,14 +295,12 @@ export function translateToAnthropic(
     }
   }
 
-  // Note: GitHub Copilot doesn't generate thinking blocks, so we don't include them in responses
-
   return {
     id: response.id,
     type: "message",
     role: "assistant",
     model: response.model,
-    content: [...allTextBlocks, ...allToolUseBlocks],
+    content: assistantContentBlocks,
     stop_reason: mapOpenAIStopReasonToAnthropic(stopReason),
     stop_sequence: null,
     usage: {
@@ -339,6 +330,31 @@ function getAnthropicTextBlocks(
       .map((part) => ({ type: "text", text: part.text }))
   }
 
+  return []
+}
+
+function getAnthropicThinkBlocks(
+  reasoningText: string | null | undefined,
+  reasoningOpaque: string | null | undefined,
+): Array<AnthropicThinkingBlock> {
+  if (reasoningText) {
+    return [
+      {
+        type: "thinking",
+        thinking: reasoningText,
+        signature: "",
+      },
+    ]
+  }
+  if (reasoningOpaque) {
+    return [
+      {
+        type: "thinking",
+        thinking: "",
+        signature: reasoningOpaque,
+      },
+    ]
+  }
   return []
 }
 

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -57,13 +57,16 @@ function handleFinish(
   const { events, chunk } = context
   if (choice.finish_reason && choice.finish_reason.length > 0) {
     if (state.contentBlockOpen) {
+      const toolBlockOpen = isToolBlockOpen(state)
       context.events.push({
         type: "content_block_stop",
         index: state.contentBlockIndex,
       })
       state.contentBlockOpen = false
       state.contentBlockIndex++
-      handleReasoningOpaque(choice.delta, events, state)
+      if (!toolBlockOpen) {
+        handleReasoningOpaque(choice.delta, events, state)
+      }
     }
 
     events.push(

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -162,7 +162,7 @@ function handleReasoningOpaqueInToolCalls(
   events: Array<AnthropicStreamEventData>,
   delta: Delta,
 ) {
-  if (state.contentBlockOpen) {
+  if (state.contentBlockOpen && !isToolBlockOpen(state)) {
     events.push({
       type: "content_block_stop",
       index: state.contentBlockIndex,

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -212,6 +212,30 @@ function handleContent(
       },
     })
   }
+
+  // handle for claude model
+  if (
+    delta.content === ""
+    && delta.reasoning_opaque
+    && delta.reasoning_opaque.length > 0
+  ) {
+    events.push(
+      {
+        type: "content_block_delta",
+        index: state.contentBlockIndex,
+        delta: {
+          type: "signature_delta",
+          signature: delta.reasoning_opaque,
+        },
+      },
+      {
+        type: "content_block_stop",
+        index: state.contentBlockIndex,
+      },
+    )
+    state.contentBlockIndex++
+    state.thinkingBlockOpen = false
+  }
 }
 
 function handleMessageStart(
@@ -313,25 +337,6 @@ function handleThinkingText(
         thinking: delta.reasoning_text,
       },
     })
-
-    if (delta.reasoning_opaque && delta.reasoning_opaque.length > 0) {
-      events.push(
-        {
-          type: "content_block_delta",
-          index: state.contentBlockIndex,
-          delta: {
-            type: "signature_delta",
-            signature: delta.reasoning_opaque,
-          },
-        },
-        {
-          type: "content_block_stop",
-          index: state.contentBlockIndex,
-        },
-      )
-      state.contentBlockIndex++
-      state.thinkingBlockOpen = false
-    }
   }
 }
 

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -1,4 +1,8 @@
-import { type ChatCompletionChunk } from "~/services/copilot/create-chat-completions"
+import {
+  type ChatCompletionChunk,
+  type Choice,
+  type Delta,
+} from "~/services/copilot/create-chat-completions"
 
 import {
   type AnthropicStreamEventData,
@@ -16,7 +20,6 @@ function isToolBlockOpen(state: AnthropicStreamState): boolean {
   )
 }
 
-// eslint-disable-next-line max-lines-per-function, complexity
 export function translateChunkToAnthropicEvents(
   chunk: ChatCompletionChunk,
   state: AnthropicStreamState,
@@ -30,22 +33,49 @@ export function translateChunkToAnthropicEvents(
   const choice = chunk.choices[0]
   const { delta } = choice
 
-  if (!state.messageStartSent) {
-    events.push({
-      type: "message_start",
-      message: {
-        id: chunk.id,
-        type: "message",
-        role: "assistant",
-        content: [],
-        model: chunk.model,
-        stop_reason: null,
-        stop_sequence: null,
+  handleMessageStart(state, events, chunk)
+
+  handleThinkingText(delta, state, events)
+
+  handleContent(delta, state, events)
+
+  handleToolCalls(delta, state, events)
+
+  handleFinish(choice, state, { events, chunk })
+
+  return events
+}
+
+function handleFinish(
+  choice: Choice,
+  state: AnthropicStreamState,
+  context: {
+    events: Array<AnthropicStreamEventData>
+    chunk: ChatCompletionChunk
+  },
+) {
+  const { events, chunk } = context
+  if (choice.finish_reason && choice.finish_reason.length > 0) {
+    if (state.contentBlockOpen) {
+      context.events.push({
+        type: "content_block_stop",
+        index: state.contentBlockIndex,
+      })
+      state.contentBlockOpen = false
+    }
+
+    events.push(
+      {
+        type: "message_delta",
+        delta: {
+          stop_reason: mapOpenAIStopReasonToAnthropic(choice.finish_reason),
+          stop_sequence: null,
+        },
         usage: {
           input_tokens:
             (chunk.usage?.prompt_tokens ?? 0)
             - (chunk.usage?.prompt_tokens_details?.cached_tokens ?? 0),
-          output_tokens: 0, // Will be updated in message_delta when finished
+          output_tokens: chunk.usage?.completion_tokens ?? 0,
           ...(chunk.usage?.prompt_tokens_details?.cached_tokens
             !== undefined && {
             cache_read_input_tokens:
@@ -53,44 +83,21 @@ export function translateChunkToAnthropicEvents(
           }),
         },
       },
-    })
-    state.messageStartSent = true
-  }
-
-  if (delta.content) {
-    if (isToolBlockOpen(state)) {
-      // A tool block was open, so close it before starting a text block.
-      events.push({
-        type: "content_block_stop",
-        index: state.contentBlockIndex,
-      })
-      state.contentBlockIndex++
-      state.contentBlockOpen = false
-    }
-
-    if (!state.contentBlockOpen) {
-      events.push({
-        type: "content_block_start",
-        index: state.contentBlockIndex,
-        content_block: {
-          type: "text",
-          text: "",
-        },
-      })
-      state.contentBlockOpen = true
-    }
-
-    events.push({
-      type: "content_block_delta",
-      index: state.contentBlockIndex,
-      delta: {
-        type: "text_delta",
-        text: delta.content,
+      {
+        type: "message_stop",
       },
-    })
+    )
   }
+}
 
-  if (delta.tool_calls) {
+function handleToolCalls(
+  delta: Delta,
+  state: AnthropicStreamState,
+  events: Array<AnthropicStreamEventData>,
+) {
+  if (delta.tool_calls && delta.tool_calls.length > 0) {
+    closeThinkingBlockIfOpen(delta, state, events)
+
     for (const toolCall of delta.tool_calls) {
       if (toolCall.id && toolCall.function?.name) {
         // New tool call starting.
@@ -141,28 +148,70 @@ export function translateChunkToAnthropicEvents(
       }
     }
   }
+}
 
-  if (choice.finish_reason) {
-    if (state.contentBlockOpen) {
+function handleContent(
+  delta: Delta,
+  state: AnthropicStreamState,
+  events: Array<AnthropicStreamEventData>,
+) {
+  if (delta.content && delta.content.length > 0) {
+    closeThinkingBlockIfOpen(delta, state, events)
+
+    if (isToolBlockOpen(state)) {
+      // A tool block was open, so close it before starting a text block.
       events.push({
         type: "content_block_stop",
         index: state.contentBlockIndex,
       })
+      state.contentBlockIndex++
       state.contentBlockOpen = false
     }
 
-    events.push(
-      {
-        type: "message_delta",
-        delta: {
-          stop_reason: mapOpenAIStopReasonToAnthropic(choice.finish_reason),
-          stop_sequence: null,
+    if (!state.contentBlockOpen) {
+      events.push({
+        type: "content_block_start",
+        index: state.contentBlockIndex,
+        content_block: {
+          type: "text",
+          text: "",
         },
+      })
+      state.contentBlockOpen = true
+    }
+
+    events.push({
+      type: "content_block_delta",
+      index: state.contentBlockIndex,
+      delta: {
+        type: "text_delta",
+        text: delta.content,
+      },
+    })
+  }
+}
+
+function handleMessageStart(
+  state: AnthropicStreamState,
+  events: Array<AnthropicStreamEventData>,
+  chunk: ChatCompletionChunk,
+) {
+  if (!state.messageStartSent) {
+    events.push({
+      type: "message_start",
+      message: {
+        id: chunk.id,
+        type: "message",
+        role: "assistant",
+        content: [],
+        model: chunk.model,
+        stop_reason: null,
+        stop_sequence: null,
         usage: {
           input_tokens:
             (chunk.usage?.prompt_tokens ?? 0)
             - (chunk.usage?.prompt_tokens_details?.cached_tokens ?? 0),
-          output_tokens: chunk.usage?.completion_tokens ?? 0,
+          output_tokens: 0, // Will be updated in message_delta when finished
           ...(chunk.usage?.prompt_tokens_details?.cached_tokens
             !== undefined && {
             cache_read_input_tokens:
@@ -170,13 +219,122 @@ export function translateChunkToAnthropicEvents(
           }),
         },
       },
+    })
+    state.messageStartSent = true
+  }
+}
+
+function handleReasoningOpaque(
+  delta: Delta,
+  events: Array<AnthropicStreamEventData>,
+  state: AnthropicStreamState,
+) {
+  if (delta.reasoning_opaque && delta.reasoning_opaque.length > 0) {
+    events.push(
       {
-        type: "message_stop",
+        type: "content_block_start",
+        index: state.contentBlockIndex,
+        content_block: {
+          type: "thinking",
+          thinking: "",
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: state.contentBlockIndex,
+        delta: {
+          type: "thinking_delta",
+          thinking: "",
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: state.contentBlockIndex,
+        delta: {
+          type: "signature_delta",
+          signature: delta.reasoning_opaque,
+        },
+      },
+      {
+        type: "content_block_stop",
+        index: state.contentBlockIndex,
       },
     )
   }
+}
 
-  return events
+function handleThinkingText(
+  delta: Delta,
+  state: AnthropicStreamState,
+  events: Array<AnthropicStreamEventData>,
+) {
+  if (delta.reasoning_text && delta.reasoning_text.length > 0) {
+    if (!state.thinkingBlockOpen) {
+      events.push({
+        type: "content_block_start",
+        index: state.contentBlockIndex,
+        content_block: {
+          type: "thinking",
+          thinking: "",
+        },
+      })
+      state.thinkingBlockOpen = true
+    }
+
+    events.push({
+      type: "content_block_delta",
+      index: state.contentBlockIndex,
+      delta: {
+        type: "thinking_delta",
+        thinking: delta.reasoning_text,
+      },
+    })
+
+    if (delta.reasoning_opaque && delta.reasoning_opaque.length > 0) {
+      events.push(
+        {
+          type: "content_block_delta",
+          index: state.contentBlockIndex,
+          delta: {
+            type: "signature_delta",
+            signature: delta.reasoning_opaque,
+          },
+        },
+        {
+          type: "content_block_stop",
+          index: state.contentBlockIndex,
+        },
+      )
+      state.contentBlockIndex++
+      state.thinkingBlockOpen = false
+    }
+  }
+}
+
+function closeThinkingBlockIfOpen(
+  delta: Delta,
+  state: AnthropicStreamState,
+  events: Array<AnthropicStreamEventData>,
+): void {
+  if (state.thinkingBlockOpen) {
+    events.push(
+      {
+        type: "content_block_delta",
+        index: state.contentBlockIndex,
+        delta: {
+          type: "signature_delta",
+          signature: "",
+        },
+      },
+      {
+        type: "content_block_stop",
+        index: state.contentBlockIndex,
+      },
+    )
+    state.contentBlockIndex++
+    state.thinkingBlockOpen = false
+  }
+  handleReasoningOpaque(delta, events, state)
 }
 
 export function translateErrorToAnthropicErrorEvent(): AnthropicStreamEventData {

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -218,6 +218,7 @@ function handleContent(
     delta.content === ""
     && delta.reasoning_opaque
     && delta.reasoning_opaque.length > 0
+    && state.thinkingBlockOpen
   ) {
     events.push(
       {
@@ -317,6 +318,15 @@ function handleThinkingText(
   events: Array<AnthropicStreamEventData>,
 ) {
   if (delta.reasoning_text && delta.reasoning_text.length > 0) {
+    // compatible with copilot API returning content->reasoning_text->reasoning_opaque in different deltas
+    // this is an extremely abnormal situation, probably a server-side bug
+    // only occurs in the claude model, with a very low probability of occurrence
+    if (state.contentBlockOpen) {
+      delta.content = delta.reasoning_text
+      delta.reasoning_text = undefined
+      return
+    }
+
     if (!state.thinkingBlockOpen) {
       events.push({
         type: "content_block_start",

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -69,7 +69,7 @@ export interface ChatCompletionChunk {
   }
 }
 
-interface Delta {
+export interface Delta {
   content?: string | null
   role?: "user" | "assistant" | "system" | "tool"
   tool_calls?: Array<{
@@ -81,9 +81,11 @@ interface Delta {
       arguments?: string
     }
   }>
+  reasoning_text?: string | null
+  reasoning_opaque?: string | null
 }
 
-interface Choice {
+export interface Choice {
   index: number
   delta: Delta
   finish_reason: "stop" | "length" | "tool_calls" | "content_filter" | null
@@ -112,6 +114,8 @@ export interface ChatCompletionResponse {
 interface ResponseMessage {
   role: "assistant"
   content: string | null
+  reasoning_text?: string | null
+  reasoning_opaque?: string | null
   tool_calls?: Array<ToolCall>
 }
 
@@ -166,6 +170,8 @@ export interface Message {
   name?: string
   tool_calls?: Array<ToolCall>
   tool_call_id?: string
+  reasoning_text?: string | null
+  reasoning_opaque?: string | null
 }
 
 export interface ToolCall {

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -152,6 +152,7 @@ export interface ChatCompletionsPayload {
     | { type: "function"; function: { name: string } }
     | null
   user?: string | null
+  thinking_budget?: number
 }
 
 export interface Tool {

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -25,6 +25,8 @@ interface ModelLimits {
 }
 
 interface ModelSupports {
+  max_thinking_budget?: number
+  min_thinking_budget?: number
   tool_calls?: boolean
   parallel_tool_calls?: boolean
   dimensions?: boolean

--- a/src/services/get-vscode-version.ts
+++ b/src/services/get-vscode-version.ts
@@ -1,4 +1,4 @@
-const FALLBACK = "1.104.3"
+const FALLBACK = "1.106.3"
 
 export async function getVSCodeVersion() {
   const controller = new AbortController()

--- a/src/services/get-vscode-version.ts
+++ b/src/services/get-vscode-version.ts
@@ -1,4 +1,4 @@
-const FALLBACK = "1.106.3"
+const FALLBACK = "1.107.0"
 
 export async function getVSCodeVersion() {
   const controller = new AbortController()

--- a/src/start.ts
+++ b/src/start.ts
@@ -117,6 +117,9 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   serve({
     fetch: server.fetch as ServerHandler,
     port: options.port,
+    bun: {
+      idleTimeout: 0,
+    },
   })
 }
 

--- a/tests/anthropic-request.test.ts
+++ b/tests/anthropic-request.test.ts
@@ -136,6 +136,7 @@ describe("Anthropic to OpenAI translation logic", () => {
             {
               type: "thinking",
               thinking: "Let me think about this simple math problem...",
+              signature: "abc123",
             },
             { type: "text", text: "2+2 equals 4." },
           ],
@@ -168,6 +169,7 @@ describe("Anthropic to OpenAI translation logic", () => {
               type: "thinking",
               thinking:
                 "I need to call the weather API to get current weather information.",
+              signature: "def456",
             },
             { type: "text", text: "I'll check the weather for you." },
             {

--- a/tests/anthropic-request.test.ts
+++ b/tests/anthropic-request.test.ts
@@ -150,7 +150,7 @@ describe("Anthropic to OpenAI translation logic", () => {
     const assistantMessage = openAIPayload.messages.find(
       (m) => m.role === "assistant",
     )
-    expect(assistantMessage?.content).toContain(
+    expect(assistantMessage?.reasoning_text).toContain(
       "Let me think about this simple math problem...",
     )
     expect(assistantMessage?.content).toContain("2+2 equals 4.")
@@ -188,7 +188,7 @@ describe("Anthropic to OpenAI translation logic", () => {
     const assistantMessage = openAIPayload.messages.find(
       (m) => m.role === "assistant",
     )
-    expect(assistantMessage?.content).toContain(
+    expect(assistantMessage?.reasoning_text).toContain(
       "I need to call the weather API",
     )
     expect(assistantMessage?.content).toContain(

--- a/tests/anthropic-response.test.ts
+++ b/tests/anthropic-response.test.ts
@@ -252,6 +252,7 @@ describe("OpenAI to Anthropic Streaming Response Translation", () => {
       contentBlockIndex: 0,
       contentBlockOpen: false,
       toolCalls: {},
+      thinkingBlockOpen: false,
     }
     const translatedStream = openAIStream.flatMap((chunk) =>
       translateChunkToAnthropicEvents(chunk, streamState),
@@ -352,6 +353,7 @@ describe("OpenAI to Anthropic Streaming Response Translation", () => {
       contentBlockIndex: 0,
       contentBlockOpen: false,
       toolCalls: {},
+      thinkingBlockOpen: false,
     }
     const translatedStream = openAIStream.flatMap((chunk) =>
       translateChunkToAnthropicEvents(chunk, streamState),


### PR DESCRIPTION
This pull request introduces significant improvements to how "thinking blocks" are handled and translated between Anthropic and OpenAI message formats. The changes ensure that reasoning and signatures are preserved during translation, add support for model-specific thinking budgets, and update protocol reminders for Claude models. Additionally, there are updates to API versioning and header intent values.

**Thinking block and reasoning support:**

* Added `signature` to `AnthropicThinkingBlock` and support for `thinkingBlockOpen` in `AnthropicStreamState` to track reasoning blocks in streaming and non-streaming message translations. [[1]](diffhunk://#diff-08afa53eccc39ed72c7319718b8243b3f207dfcb789e9d4648ca9b21dc6a05acR59) [[2]](diffhunk://#diff-08afa53eccc39ed72c7319718b8243b3f207dfcb789e9d4648ca9b21dc6a05acR200) [[3]](diffhunk://#diff-b1df1c0e29b6771054bca26a0d273fdef182c05a8d1ff11902c12f1d5ab16596R63)
* Updated translation logic to preserve `reasoning_text` and `reasoning_opaque` (signature) when converting between Anthropic and OpenAI formats, including new functions for extracting and injecting thinking blocks. [[1]](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87L142-R247) [[2]](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87R262-R263) [[3]](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87L285-R389) [[4]](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87L332-R409) [[5]](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87R422-R446)

**Model-specific protocol and budget enforcement:**

* Added logic to inject system reminders and enforce interleaved thinking protocol for Claude models, and to calculate and pass a `thinking_budget` based on model capabilities. [[1]](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87R34-R42) [[2]](diffhunk://#diff-b102fe66fa1642a9ef5cac4e6baabf3506bc3d5b221246ea3d978f136d606b87R52-R155)

**API and header updates:**

* Updated Copilot and API version numbers, and changed `openai-intent` header from `conversation-panel` to `conversation-agent` for requests. [[1]](diffhunk://#diff-18a24f767228788c87f3f2e8a28ebee5551da07bb32f301eb319d4329db0b859L10-R14) [[2]](diffhunk://#diff-18a24f767228788c87f3f2e8a28ebee5551da07bb32f301eb319d4329db0b859L28-R28)

**Token counting improvements:**

* Excluded `reasoning_opaque` from token counting when calculating message tokens to avoid miscounting opaque reasoning signatures.

**Streaming translation refactor:**

* Refactored streaming translation logic to support thinking block handling and reasoning extraction, improving event sequencing for message starts, content, tool calls, and finish events. [[1]](diffhunk://#diff-7951f8b2958d2ff38e99b06a118fa99f620d63648903a40af281393ca8f2a3c6L1-R5) [[2]](diffhunk://#diff-7951f8b2958d2ff38e99b06a118fa99f620d63648903a40af281393ca8f2a3c6L19) [[3]](diffhunk://#diff-7951f8b2958d2ff38e99b06a118fa99f620d63648903a40af281393ca8f2a3c6L33-L93)

These updates collectively enhance the fidelity and protocol compliance of message translations between Anthropic and OpenAI, especially for Claude models.