### PR TITLE
Feature/fix tool 400 error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ node_modules/
 .eslintcache
 
 # build output
-dist/
+dist/.DS_Store

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -239,9 +239,24 @@ function translateAnthropicToolsToOpenAI(
     function: {
       name: tool.name,
       description: tool.description,
-      parameters: tool.input_schema,
+      parameters: normalizeToolParameters(tool.input_schema),
     },
   }))
+}
+
+function normalizeToolParameters(
+  inputSchema: unknown,
+): Record<string, unknown> {
+  if (!inputSchema || typeof inputSchema !== "object") {
+    return { type: "object", properties: {} }
+  }
+
+  const schema = { ...inputSchema } as Record<string, unknown>
+  if (schema.type === "object" && schema.properties === undefined) {
+    return { ...schema, properties: {} }
+  }
+
+  return schema
 }
 
 function translateAnthropicToolChoiceToOpenAI(


### PR DESCRIPTION
Background
When calling Copilot chat completions, we received a 400 error:
`Invalid schema for function 'mcp__pencil__get_style_guide_tags': In context=(), object schema missing properties.
`

Change
Add a defensive normalization step so any tool parameter schema with [type: "object"] always includes a [properties]field before sending to Copilot.

Result
Fixes the invalid_function_parameters error and allows tool calls to be accepted correctly by Copilot.