### PR TITLE
Add Responses API support and model-level routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ These endpoints mimic the OpenAI API structure.
 | Endpoint                    | Method | Description                                               |
 | --------------------------- | ------ | --------------------------------------------------------- |
 | `POST /v1/chat/completions` | `POST` | Creates a model response for the given chat conversation. |
+| `POST /v1/responses`        | `POST` | Creates a model response using the Responses API format.  |
 | `GET /v1/models`            | `GET`  | Lists the currently available models.                     |
 | `POST /v1/embeddings`       | `POST` | Creates an embedding vector representing the input text.  |
 

--- a/src/lib/model-level.ts
+++ b/src/lib/model-level.ts
@@ -1,0 +1,38 @@
+export const MODEL_LEVELS = ["low", "medium", "high", "xhigh"] as const
+
+export type ModelLevel = (typeof MODEL_LEVELS)[number]
+
+export const MODEL_LEVEL_VARIANTS = {
+  "gpt-5.3-codex": MODEL_LEVELS,
+  "claude-opus-4.6": ["low", "medium", "high"],
+  "claude-opus-4.6-fast": ["low", "medium", "high"],
+  "claude-sonnet-4.6": ["low", "medium", "high"],
+} as const satisfies Record<string, ReadonlyArray<ModelLevel>>
+
+export const parseModelNameWithLevel = (
+  model: string,
+): {
+  baseModel: string
+  level: ModelLevel | undefined
+} => {
+  const match = model.match(/^(.+)\((low|medium|high|xhigh)\)$/)
+  if (!match) {
+    return {
+      baseModel: model,
+      level: undefined,
+    }
+  }
+
+  return {
+    baseModel: match[1],
+    level: match[2] as ModelLevel,
+  }
+}
+
+export const isCodexResponsesModel = (model: string): boolean =>
+  model === "gpt-5.3-codex"
+
+export const isClaudeThinkingModel = (model: string): boolean =>
+  model === "claude-opus-4.6"
+  || model === "claude-opus-4.6-fast"
+  || model === "claude-sonnet-4.6"

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -4,6 +4,10 @@ import consola from "consola"
 import { streamSSE, type SSEMessage } from "hono/streaming"
 
 import { awaitApproval } from "~/lib/approval"
+import {
+  isCodexResponsesModel,
+  parseModelNameWithLevel,
+} from "~/lib/model-level"
 import { checkRateLimit } from "~/lib/rate-limit"
 import { state } from "~/lib/state"
 import { getTokenCount } from "~/lib/tokenizer"
@@ -12,17 +16,29 @@ import {
   createChatCompletions,
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
+  normalizeChatCompletionsPayloadModel,
 } from "~/services/copilot/create-chat-completions"
+import {
+  createResponses,
+  type ResponsesApiResponse,
+} from "~/services/copilot/create-responses"
+
+import {
+  translateChatCompletionsToResponses,
+  translateResponsesStreamToChatStream,
+  translateResponsesToChatCompletions,
+} from "./responses-translation"
 
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
 
   let payload = await c.req.json<ChatCompletionsPayload>()
+  const { baseModel } = parseModelNameWithLevel(payload.model)
   consola.debug("Request payload:", JSON.stringify(payload).slice(-400))
 
   // Find the selected model
   const selectedModel = state.models?.data.find(
-    (model) => model.id === payload.model,
+    (model) => model.id === baseModel,
   )
 
   // Calculate and display token count
@@ -47,7 +63,33 @@ export async function handleCompletion(c: Context) {
     consola.debug("Set max_tokens to:", JSON.stringify(payload.max_tokens))
   }
 
-  const response = await createChatCompletions(payload)
+  const normalizedPayload = normalizeChatCompletionsPayloadModel(payload)
+
+  if (isCodexResponsesModel(baseModel)) {
+    const responsesPayload =
+      translateChatCompletionsToResponses(normalizedPayload)
+    const responses = await createResponses(responsesPayload)
+
+    if (isNonStreamingResponse(responses)) {
+      const completionResponse = translateResponsesToChatCompletions(responses)
+      consola.debug(
+        "Codex translated response:",
+        JSON.stringify(completionResponse).slice(-400),
+      )
+      return c.json(completionResponse)
+    }
+
+    return streamSSE(c, async (stream) => {
+      for await (const chunk of translateResponsesStreamToChatStream(
+        responses,
+        normalizedPayload.model,
+      )) {
+        await stream.writeSSE(chunk)
+      }
+    })
+  }
+
+  const response = await createChatCompletions(normalizedPayload)
 
   if (isNonStreaming(response)) {
     consola.debug("Non-streaming response:", JSON.stringify(response))
@@ -62,6 +104,10 @@ export async function handleCompletion(c: Context) {
     }
   })
 }
+
+const isNonStreamingResponse = (
+  response: Awaited<ReturnType<typeof createResponses>>,
+): response is ResponsesApiResponse => !(Symbol.asyncIterator in response)
 
 const isNonStreaming = (
   response: Awaited<ReturnType<typeof createChatCompletions>>,

--- a/src/routes/chat-completions/responses-translation.ts
+++ b/src/routes/chat-completions/responses-translation.ts
@@ -1,0 +1,253 @@
+import type { SSEMessage } from "hono/streaming"
+
+import { randomUUID } from "node:crypto"
+
+import type {
+  ChatCompletionChunk,
+  ChatCompletionResponse,
+  ChatCompletionsPayload,
+  ContentPart,
+  Message,
+  ToolCall,
+} from "~/services/copilot/create-chat-completions"
+import type {
+  ResponseInputContentPart,
+  ResponseInputMessage,
+  ResponsesApiResponse,
+  ResponsesFunctionCall,
+  ResponsesOutputContentPart,
+  ResponsesOutputItem,
+  ResponsesPayload,
+} from "~/services/copilot/create-responses"
+
+export function translateChatCompletionsToResponses(
+  payload: ChatCompletionsPayload,
+): ResponsesPayload {
+  return {
+    model: payload.model,
+    input: payload.messages.map((message) => translateMessage(message)),
+    stream: payload.stream,
+    temperature: payload.temperature,
+    top_p: payload.top_p,
+    max_output_tokens: payload.max_tokens,
+    stop: payload.stop,
+    tools: payload.tools as Array<unknown> | null | undefined,
+    tool_choice: payload.tool_choice,
+    user: payload.user,
+    reasoning_effort: payload.reasoning_effort,
+    reasoning:
+      payload.reasoning
+      ?? (payload.reasoning_effort ?
+        {
+          effort: payload.reasoning_effort,
+        }
+      : undefined),
+  }
+}
+
+export function translateResponsesToChatCompletions(
+  response: ResponsesApiResponse,
+): ChatCompletionResponse {
+  const outputItems = response.output ?? []
+  const messageContent = extractOutputText(outputItems, response.output_text)
+  const toolCalls = extractToolCalls(outputItems)
+  const completionTokens = response.usage?.output_tokens ?? 0
+  const promptTokens = response.usage?.input_tokens ?? 0
+
+  return {
+    id: response.id,
+    object: "chat.completion",
+    created: response.created_at ?? Math.floor(Date.now() / 1000),
+    model: response.model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: messageContent.length > 0 ? messageContent : null,
+          ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
+        },
+        logprobs: null,
+        finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens:
+        response.usage?.total_tokens ?? promptTokens + completionTokens,
+    },
+  }
+}
+
+export async function* translateResponsesStreamToChatStream(
+  responseStream: AsyncIterable<{ data?: string }>,
+  model: string,
+): AsyncGenerator<SSEMessage> {
+  const completionId = randomUUID()
+  const created = Math.floor(Date.now() / 1000)
+  let hasEmittedContent = false
+
+  for await (const rawEvent of responseStream) {
+    if (rawEvent.data === "[DONE]") {
+      const endChunk: ChatCompletionChunk = {
+        id: completionId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: "stop",
+            logprobs: null,
+          },
+        ],
+      }
+      yield { data: JSON.stringify(endChunk) }
+      yield { data: "[DONE]" }
+      return
+    }
+
+    if (!rawEvent.data) {
+      continue
+    }
+
+    const parsedEvent = JSON.parse(rawEvent.data) as {
+      type?: string
+      delta?: string
+    }
+
+    if (
+      parsedEvent.type === "response.output_text.delta"
+      && typeof parsedEvent.delta === "string"
+    ) {
+      const chunk: ChatCompletionChunk = {
+        id: completionId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              ...(hasEmittedContent ? {} : { role: "assistant" }),
+              content: parsedEvent.delta,
+            },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      }
+      hasEmittedContent = true
+      yield { data: JSON.stringify(chunk) }
+    }
+  }
+}
+
+function translateMessage(message: Message): ResponseInputMessage {
+  let content: ResponseInputMessage["content"]
+  if (typeof message.content === "string") {
+    content = message.content
+  } else if (message.content === null) {
+    content = ""
+  } else {
+    content = message.content.map((part) => translateContentPart(part))
+  }
+
+  return {
+    role: message.role,
+    content,
+  }
+}
+
+function translateContentPart(part: ContentPart): ResponseInputContentPart {
+  if (part.type === "text") {
+    return {
+      type: "input_text",
+      text: part.text,
+    }
+  }
+
+  return {
+    type: "input_image",
+    image_url: part.image_url.url,
+    detail: part.image_url.detail,
+  }
+}
+
+function extractOutputText(
+  outputItems: Array<ResponsesOutputItem>,
+  outputText: string | undefined,
+): string {
+  if (outputText) {
+    return outputText
+  }
+
+  const parts = outputItems.flatMap((item) => {
+    if (item.type !== "message") {
+      return []
+    }
+
+    if (typeof item.content === "string") {
+      return [item.content]
+    }
+
+    if (!Array.isArray(item.content)) {
+      return []
+    }
+
+    return item.content.flatMap((contentPart) =>
+      contentPart.type === "output_text" ? [contentPart.text] : [],
+    )
+  })
+
+  return parts.join("")
+}
+
+function extractToolCalls(
+  outputItems: Array<ResponsesOutputItem>,
+): Array<ToolCall> {
+  const toolCalls: Array<ToolCall> = []
+  for (const item of outputItems) {
+    if (item.type === "function_call") {
+      toolCalls.push(translateFunctionCall(item))
+      continue
+    }
+
+    if (typeof item.content === "string" || !Array.isArray(item.content)) {
+      continue
+    }
+
+    for (const contentPart of item.content) {
+      if (isResponsesFunctionCall(contentPart)) {
+        toolCalls.push(translateFunctionCall(contentPart))
+      }
+    }
+  }
+
+  return toolCalls
+}
+
+function translateFunctionCall(functionCall: ResponsesFunctionCall): ToolCall {
+  return {
+    id: functionCall.call_id ?? functionCall.id ?? randomUUID(),
+    type: "function",
+    function: {
+      name: functionCall.name,
+      arguments: functionCall.arguments,
+    },
+  }
+}
+
+function isResponsesFunctionCall(
+  value: ResponsesOutputContentPart,
+): value is ResponsesFunctionCall {
+  return (
+    value.type === "function_call"
+    && "name" in value
+    && typeof value.name === "string"
+    && "arguments" in value
+    && typeof value.arguments === "string"
+  )
+}

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -40,6 +40,7 @@ export function translateToOpenAI(
     stream: payload.stream,
     temperature: payload.temperature,
     top_p: payload.top_p,
+    thinking: payload.thinking,
     user: payload.metadata?.user_id,
     tools: translateAnthropicToolsToOpenAI(payload.tools),
     tool_choice: translateAnthropicToolChoiceToOpenAI(payload.tool_choice),
@@ -48,9 +49,15 @@ export function translateToOpenAI(
 
 function translateModelName(model: string): string {
   // Subagent requests use a specific model number which Copilot doesn't support
-  if (model.startsWith("claude-sonnet-4-")) {
+  if (
+    model.startsWith("claude-sonnet-4-")
+    && !model.startsWith("claude-sonnet-4.6")
+  ) {
     return model.replace(/^claude-sonnet-4-.*/, "claude-sonnet-4")
-  } else if (model.startsWith("claude-opus-")) {
+  } else if (
+    model.startsWith("claude-opus-4-")
+    && !model.startsWith("claude-opus-4.6")
+  ) {
     return model.replace(/^claude-opus-4-.*/, "claude-opus-4")
   }
   return model

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono"
 
+import type { Model } from "~/services/copilot/get-models"
+
 import { forwardError } from "~/lib/error"
+import { MODEL_LEVEL_VARIANTS } from "~/lib/model-level"
 import { state } from "~/lib/state"
 import { cacheModels } from "~/lib/utils"
 
@@ -13,15 +16,7 @@ modelRoutes.get("/", async (c) => {
       await cacheModels()
     }
 
-    const models = state.models?.data.map((model) => ({
-      id: model.id,
-      object: "model",
-      type: "model",
-      created: 0, // No date available from source
-      created_at: new Date(0).toISOString(), // No date available from source
-      owned_by: model.vendor,
-      display_name: model.name,
-    }))
+    const models = expandModelList(state.models?.data ?? [])
 
     return c.json({
       object: "list",
@@ -32,3 +27,34 @@ modelRoutes.get("/", async (c) => {
     return await forwardError(c, error)
   }
 })
+
+export function expandModelList(models: Array<Model>) {
+  return models.flatMap((model) => {
+    const expanded = [toModelItem(model, model.id)]
+    const levels =
+      model.id in MODEL_LEVEL_VARIANTS ?
+        MODEL_LEVEL_VARIANTS[model.id as keyof typeof MODEL_LEVEL_VARIANTS]
+      : undefined
+    if (!levels) {
+      return expanded
+    }
+
+    for (const level of levels) {
+      expanded.push(toModelItem(model, `${model.id}(${level})`))
+    }
+
+    return expanded
+  })
+}
+
+function toModelItem(model: Model, id: string) {
+  return {
+    id,
+    object: "model",
+    type: "model",
+    created: 0,
+    created_at: new Date(0).toISOString(),
+    owned_by: model.vendor,
+    display_name: model.name,
+  }
+}

--- a/src/routes/responses/route.ts
+++ b/src/routes/responses/route.ts
@@ -1,0 +1,40 @@
+import { Hono } from "hono"
+import { streamSSE, type SSEMessage } from "hono/streaming"
+
+import { awaitApproval } from "~/lib/approval"
+import { forwardError } from "~/lib/error"
+import { checkRateLimit } from "~/lib/rate-limit"
+import { state } from "~/lib/state"
+import {
+  createResponses,
+  type ResponsesApiResponse,
+  type ResponsesPayload,
+} from "~/services/copilot/create-responses"
+
+export const responsesRoutes = new Hono()
+
+responsesRoutes.post("/", async (c) => {
+  try {
+    await checkRateLimit(state)
+
+    const payload = await c.req.json<ResponsesPayload>()
+    if (state.manualApprove) await awaitApproval()
+
+    const response = await createResponses(payload)
+    if (isNonStreamingResponse(response)) {
+      return c.json(response)
+    }
+
+    return streamSSE(c, async (stream) => {
+      for await (const chunk of response) {
+        await stream.writeSSE(chunk as SSEMessage)
+      }
+    })
+  } catch (error) {
+    return await forwardError(c, error)
+  }
+})
+
+const isNonStreamingResponse = (
+  response: Awaited<ReturnType<typeof createResponses>>,
+): response is ResponsesApiResponse => !(Symbol.asyncIterator in response)

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { completionRoutes } from "./routes/chat-completions/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
 import { modelRoutes } from "./routes/models/route"
+import { responsesRoutes } from "./routes/responses/route"
 import { tokenRoute } from "./routes/token/route"
 import { usageRoute } from "./routes/usage/route"
 
@@ -21,11 +22,13 @@ server.route("/models", modelRoutes)
 server.route("/embeddings", embeddingRoutes)
 server.route("/usage", usageRoute)
 server.route("/token", tokenRoute)
+server.route("/responses", responsesRoutes)
 
 // Compatibility with tools that expect v1/ prefix
 server.route("/v1/chat/completions", completionRoutes)
 server.route("/v1/models", modelRoutes)
 server.route("/v1/embeddings", embeddingRoutes)
+server.route("/v1/responses", responsesRoutes)
 
 // Anthropic compatible endpoints
 server.route("/v1/messages", messageRoutes)

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -3,14 +3,22 @@ import { events } from "fetch-event-stream"
 
 import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import {
+  isClaudeThinkingModel,
+  isCodexResponsesModel,
+  parseModelNameWithLevel,
+  type ModelLevel,
+} from "~/lib/model-level"
 import { state } from "~/lib/state"
 
 export const createChatCompletions = async (
   payload: ChatCompletionsPayload,
 ) => {
+  const normalizedPayload = normalizeChatCompletionsPayloadModel(payload)
+
   if (!state.copilotToken) throw new Error("Copilot token not found")
 
-  const enableVision = payload.messages.some(
+  const enableVision = normalizedPayload.messages.some(
     (x) =>
       typeof x.content !== "string"
       && x.content?.some((x) => x.type === "image_url"),
@@ -18,7 +26,7 @@ export const createChatCompletions = async (
 
   // Agent/user check for X-Initiator header
   // Determine if any message is from an agent ("assistant" or "tool")
-  const isAgentCall = payload.messages.some((msg) =>
+  const isAgentCall = normalizedPayload.messages.some((msg) =>
     ["assistant", "tool"].includes(msg.role),
   )
 
@@ -31,7 +39,7 @@ export const createChatCompletions = async (
   const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
     method: "POST",
     headers,
-    body: JSON.stringify(payload),
+    body: JSON.stringify(normalizedPayload),
   })
 
   if (!response.ok) {
@@ -39,12 +47,50 @@ export const createChatCompletions = async (
     throw new HTTPError("Failed to create chat completions", response)
   }
 
-  if (payload.stream) {
+  if (normalizedPayload.stream) {
     return events(response)
   }
 
   return (await response.json()) as ChatCompletionResponse
 }
+
+export const normalizeChatCompletionsPayloadModel = (
+  payload: ChatCompletionsPayload,
+): ChatCompletionsPayload => {
+  const { baseModel, level } = parseModelNameWithLevel(payload.model)
+  if (!level) {
+    return payload
+  }
+
+  const nextPayload: ChatCompletionsPayload = {
+    ...payload,
+    model: baseModel,
+  }
+
+  if (isCodexResponsesModel(baseModel)) {
+    nextPayload.reasoning_effort = level
+    return nextPayload
+  }
+
+  if (isClaudeThinkingModel(baseModel) && level !== "xhigh") {
+    const currentThinking =
+      isRecord(payload.thinking) ? payload.thinking : ({} as ThinkingConfig)
+    nextPayload.reasoning_effort = level
+    nextPayload.thinking = {
+      ...currentThinking,
+      type:
+        typeof currentThinking.type === "string" ?
+          currentThinking.type
+        : "enabled",
+      effort: level,
+    }
+  }
+
+  return nextPayload
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
 
 // Streaming types
 
@@ -148,6 +194,17 @@ export interface ChatCompletionsPayload {
     | { type: "function"; function: { name: string } }
     | null
   user?: string | null
+  reasoning_effort?: ModelLevel | null
+  reasoning?: {
+    effort?: ModelLevel
+  } | null
+  thinking?: ThinkingConfig | null
+}
+
+interface ThinkingConfig {
+  type?: string
+  effort?: ModelLevel
+  [key: string]: unknown
 }
 
 export interface Tool {

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1,0 +1,98 @@
+import consola from "consola"
+import { events } from "fetch-event-stream"
+
+import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
+import { HTTPError } from "~/lib/error"
+import { type ModelLevel } from "~/lib/model-level"
+import { state } from "~/lib/state"
+
+export const createResponses = async (payload: ResponsesPayload) => {
+  if (!state.copilotToken) throw new Error("Copilot token not found")
+
+  const response = await fetch(`${copilotBaseUrl(state)}/v1/responses`, {
+    method: "POST",
+    headers: copilotHeaders(state),
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok) {
+    consola.error("Failed to create response", response)
+    throw new HTTPError("Failed to create response", response)
+  }
+
+  if (payload.stream) {
+    return events(response)
+  }
+
+  return (await response.json()) as ResponsesApiResponse
+}
+
+export interface ResponsesPayload {
+  model: string
+  input: string | Array<ResponseInputMessage>
+  stream?: boolean | null
+  temperature?: number | null
+  top_p?: number | null
+  max_output_tokens?: number | null
+  stop?: string | Array<string> | null
+  tools?: Array<unknown> | null
+  tool_choice?: unknown
+  user?: string | null
+  reasoning_effort?: ModelLevel | null
+  reasoning?: {
+    effort?: ModelLevel
+  } | null
+}
+
+export interface ResponseInputMessage {
+  role: "user" | "assistant" | "system" | "tool" | "developer"
+  content: string | Array<ResponseInputContentPart>
+}
+
+export interface ResponseInputContentPart {
+  type: "input_text" | "input_image"
+  text?: string
+  image_url?: string
+  detail?: "low" | "high" | "auto"
+}
+
+export interface ResponsesApiResponse {
+  id: string
+  object: string
+  created_at?: number
+  model: string
+  output?: Array<ResponsesOutputItem>
+  output_text?: string
+  usage?: {
+    input_tokens?: number
+    output_tokens?: number
+    total_tokens?: number
+  }
+}
+
+export type ResponsesOutputItem = ResponsesOutputMessage | ResponsesFunctionCall
+
+export interface ResponsesOutputMessage {
+  type: "message"
+  role: "assistant" | "user" | "system" | "tool"
+  content: string | Array<ResponsesOutputContentPart>
+}
+
+export type ResponsesOutputContentPart =
+  | {
+      type: "output_text"
+      text: string
+    }
+  | ResponsesFunctionCall
+  | {
+      type: string
+      [key: string]: unknown
+    }
+
+export interface ResponsesFunctionCall {
+  type: "function_call"
+  name: string
+  arguments: string
+  call_id?: string
+  id?: string
+}

--- a/tests/phase5-routing.test.ts
+++ b/tests/phase5-routing.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test"
+
+import type { Model } from "~/services/copilot/get-models"
+
+import {
+  MODEL_LEVEL_VARIANTS,
+  parseModelNameWithLevel,
+} from "~/lib/model-level"
+import {
+  translateChatCompletionsToResponses,
+  translateResponsesToChatCompletions,
+} from "~/routes/chat-completions/responses-translation"
+import { expandModelList } from "~/routes/models/route"
+import { normalizeChatCompletionsPayloadModel } from "~/services/copilot/create-chat-completions"
+
+describe("model(level) parsing and mapping", () => {
+  test("parses suffixed model name", () => {
+    expect(parseModelNameWithLevel("gpt-5.3-codex(high)")).toEqual({
+      baseModel: "gpt-5.3-codex",
+      level: "high",
+    })
+  })
+
+  test("keeps plain model untouched", () => {
+    expect(parseModelNameWithLevel("claude-sonnet-4.6")).toEqual({
+      baseModel: "claude-sonnet-4.6",
+      level: undefined,
+    })
+  })
+
+  test("maps codex suffix level to reasoning_effort", () => {
+    const payload = normalizeChatCompletionsPayloadModel({
+      model: "gpt-5.3-codex(xhigh)",
+      messages: [{ role: "user", content: "hi" }],
+    })
+
+    expect(payload.model).toBe("gpt-5.3-codex")
+    expect(payload.reasoning_effort).toBe("xhigh")
+  })
+
+  test("maps claude suffix level while preserving thinking fields", () => {
+    const payload = normalizeChatCompletionsPayloadModel({
+      model: "claude-opus-4.6(high)",
+      messages: [{ role: "user", content: "hi" }],
+      thinking: { budget_tokens: 4096 },
+    })
+
+    expect(payload.model).toBe("claude-opus-4.6")
+    expect(payload.reasoning_effort).toBe("high")
+    expect(payload.thinking).toEqual({
+      budget_tokens: 4096,
+      effort: "high",
+      type: "enabled",
+    })
+  })
+})
+
+describe("chat/responses translation", () => {
+  test("translates chat payload to responses payload", () => {
+    const translated = translateChatCompletionsToResponses({
+      model: "gpt-5.3-codex",
+      messages: [{ role: "user", content: "Hello" }],
+      max_tokens: 128,
+      reasoning_effort: "medium",
+    })
+
+    expect(translated).toMatchObject({
+      model: "gpt-5.3-codex",
+      input: [{ role: "user", content: "Hello" }],
+      max_output_tokens: 128,
+      reasoning_effort: "medium",
+      reasoning: { effort: "medium" },
+    })
+  })
+
+  test("translates responses payload back to chat completion", () => {
+    const translated = translateResponsesToChatCompletions({
+      id: "resp_123",
+      object: "response",
+      created_at: 123,
+      model: "gpt-5.3-codex",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Hello from responses" }],
+        },
+      ],
+      usage: { input_tokens: 2, output_tokens: 4, total_tokens: 6 },
+    })
+
+    expect(translated.object).toBe("chat.completion")
+    expect(translated.choices[0]?.message.content).toBe("Hello from responses")
+    expect(translated.usage).toEqual({
+      prompt_tokens: 2,
+      completion_tokens: 4,
+      total_tokens: 6,
+    })
+  })
+})
+
+describe("model listing expansion", () => {
+  test("includes required level-suffixed variants", () => {
+    const models = expandModelList([
+      makeModel("gpt-5.3-codex"),
+      makeModel("claude-opus-4.6"),
+      makeModel("claude-opus-4.6-fast"),
+      makeModel("claude-sonnet-4.6"),
+      makeModel("gpt-4.1"),
+    ])
+    const ids = models.map((model) => model.id)
+
+    expect(ids).toContain("gpt-5.3-codex")
+    for (const level of MODEL_LEVEL_VARIANTS["gpt-5.3-codex"]) {
+      expect(ids).toContain(`gpt-5.3-codex(${level})`)
+    }
+    for (const level of MODEL_LEVEL_VARIANTS["claude-opus-4.6"]) {
+      expect(ids).toContain(`claude-opus-4.6(${level})`)
+      expect(ids).toContain(`claude-opus-4.6-fast(${level})`)
+      expect(ids).toContain(`claude-sonnet-4.6(${level})`)
+    }
+    expect(ids).toContain("gpt-4.1")
+  })
+})
+
+function makeModel(id: string): Model {
+  return {
+    id,
+    name: id,
+    object: "model",
+    model_picker_enabled: true,
+    preview: false,
+    vendor: "test",
+    version: "1",
+    capabilities: {
+      family: "test",
+      limits: {},
+      object: "model_capabilities",
+      supports: {},
+      tokenizer: "test",
+      type: "chat",
+    },
+  }
+}


### PR DESCRIPTION
This adds support for the Responses API, which is needed for gpt-5.3-codex since that model doesn't work through the chat/completions endpoint.

Changes:
- Requests for codex models sent to /v1/chat/completions are transparently translated to/from the Responses API format
- Added a direct /v1/responses passthrough endpoint
- Model names can include a reasoning level suffix like model(high) or model(xhigh) which sets reasoning_effort on the request
- /v1/models now lists the level-suffixed variants for supported models
- Claude thinking config is passed through when a level suffix is used
- Fixed translateModelName so it doesn't incorrectly rewrite 4.6 model names

Tested against the live Copilot API with all model+level combinations.