### PR TITLE
feat: add OpenAI Responses API endpoint support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "copilot-api",

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -1,0 +1,81 @@
+import type { Context } from "hono"
+
+import consola from "consola"
+import { streamSSE } from "hono/streaming"
+
+import { awaitApproval } from "~/lib/approval"
+import { checkRateLimit } from "~/lib/rate-limit"
+import { state } from "~/lib/state"
+import { isNullish } from "~/lib/utils"
+import {
+  createResponses,
+  type ResponsesPayload,
+} from "~/services/copilot/create-responses"
+
+export async function handleResponses(c: Context) {
+  await checkRateLimit(state)
+
+  const payload = await c.req.json<ResponsesPayload>()
+  consola.debug(
+    "Responses API request payload:",
+    JSON.stringify(payload).slice(-400),
+  )
+
+  // Set default max_output_tokens from model capabilities
+  const selectedModel = state.models?.data.find(
+    (model) => model.id === payload.model,
+  )
+
+  if (state.manualApprove) await awaitApproval()
+
+  if (isNullish(payload.max_output_tokens)) {
+    payload.max_output_tokens =
+      selectedModel?.capabilities.limits.max_output_tokens
+    consola.debug("Set max_output_tokens to:", payload.max_output_tokens)
+  }
+
+  const response = await createResponses(payload)
+
+  // Non-streaming: response is a JSON object with "object" field
+  if (isNonStreaming(response)) {
+    consola.debug(
+      "Non-streaming responses result:",
+      JSON.stringify(response).slice(-400),
+    )
+    return c.json(response)
+  }
+
+  // Streaming: forward SSE events directly from Copilot
+  consola.debug("Streaming responses result")
+  return streamSSE(c, async (stream) => {
+    for await (const rawEvent of response) {
+      consola.debug("Responses stream event:", JSON.stringify(rawEvent))
+
+      if (rawEvent.data === "[DONE]") {
+        break
+      }
+
+      if (!rawEvent.data) {
+        continue
+      }
+
+      // Extract event type from the data for the SSE event field
+      try {
+        const parsed = JSON.parse(rawEvent.data) as { type?: string }
+        await stream.writeSSE({
+          event: parsed.type ?? rawEvent.event ?? "message",
+          data: rawEvent.data,
+        })
+      } catch {
+        await stream.writeSSE({
+          event: rawEvent.event ?? "message",
+          data: rawEvent.data,
+        })
+      }
+    }
+  })
+}
+
+const isNonStreaming = (
+  response: Awaited<ReturnType<typeof createResponses>>,
+): response is Record<string, unknown> => Object.hasOwn(response, "object")

--- a/src/routes/responses/route.ts
+++ b/src/routes/responses/route.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono"
+
+import { forwardError } from "~/lib/error"
+
+import { handleResponses } from "./handler"
+
+export const responsesRoutes = new Hono()
+
+responsesRoutes.post("/", async (c) => {
+  try {
+    return await handleResponses(c)
+  } catch (error) {
+    return await forwardError(c, error)
+  }
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { completionRoutes } from "./routes/chat-completions/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
 import { modelRoutes } from "./routes/models/route"
+import { responsesRoutes } from "./routes/responses/route"
 import { tokenRoute } from "./routes/token/route"
 import { usageRoute } from "./routes/usage/route"
 
@@ -26,6 +27,10 @@ server.route("/token", tokenRoute)
 server.route("/v1/chat/completions", completionRoutes)
 server.route("/v1/models", modelRoutes)
 server.route("/v1/embeddings", embeddingRoutes)
+
+// OpenAI Responses API endpoints
+server.route("/v1/responses", responsesRoutes)
+server.route("/responses", responsesRoutes)
 
 // Anthropic compatible endpoints
 server.route("/v1/messages", messageRoutes)

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1,0 +1,75 @@
+import consola from "consola"
+import { events } from "fetch-event-stream"
+
+import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
+import { HTTPError } from "~/lib/error"
+import { state } from "~/lib/state"
+
+export interface ResponsesPayload {
+  model: string
+  input: string | Array<ResponseInputItem>
+  instructions?: string | null
+  stream?: boolean | null
+  temperature?: number | null
+  top_p?: number | null
+  max_output_tokens?: number | null
+  [key: string]: unknown
+}
+
+type ResponseInputItem = {
+  type?: string
+  role?: string
+  content?: string | Array<{ type: string; [key: string]: unknown }>
+  [key: string]: unknown
+}
+
+export const createResponses = async (payload: ResponsesPayload) => {
+  if (!state.copilotToken) throw new Error("Copilot token not found")
+
+  const enableVision = hasVisionContent(payload)
+  const isAgentCall = hasAgentMessages(payload)
+
+  const headers: Record<string, string> = {
+    ...copilotHeaders(state, enableVision),
+    "X-Initiator": isAgentCall ? "agent" : "user",
+  }
+
+  const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok) {
+    consola.error("Failed to create responses", response)
+    throw new HTTPError("Failed to create responses", response)
+  }
+
+  if (payload.stream) {
+    return events(response)
+  }
+
+  return (await response.json()) as Record<string, unknown>
+}
+
+function hasVisionContent(payload: ResponsesPayload): boolean {
+  if (typeof payload.input === "string") return false
+
+  return payload.input.some((item) => {
+    if (Array.isArray(item.content)) {
+      return item.content.some((part) => part.type === "input_image")
+    }
+    return false
+  })
+}
+
+function hasAgentMessages(payload: ResponsesPayload): boolean {
+  if (typeof payload.input === "string") return false
+
+  return payload.input.some((item) => {
+    if (item.role === "assistant") return true
+    if (item.type === "function_call_output") return true
+    if (item.type === "function_call") return true
+    return false
+  })
+}


### PR DESCRIPTION
## Summary

- Add `/v1/responses` and `/responses` endpoints that forward requests directly to GitHub Copilot's responses API
- Enables support for responses-only models (gpt-5.4, gpt-5.3-codex, etc.)
- Follows existing project patterns: rate limiting, manual approval, vision detection, X-Initiator header

## Changes

- `src/services/copilot/create-responses.ts` — Copilot responses API client
- `src/routes/responses/route.ts` — Route registration with error handling
- `src/routes/responses/handler.ts` — Request handler (streaming + non-streaming)
- `src/server.ts` — Register new endpoints

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes (pre-commit hook)
- [x] Tested gpt-5.4 non-streaming — returns correct response
- [x] Tested gpt-5.4 streaming — full SSE event chain works
- [x] Tested gpt-5.3-codex non-streaming — returns correct response
- [x] Verified gpt-4o correctly returns `unsupported_api_for_model` error
- [x] Existing endpoints unaffected (backward compatible)