### PR TITLE
fix(messages): normalize versioned Claude model names

### DIFF
--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -47,11 +47,12 @@ export function translateToOpenAI(
 }
 
 function translateModelName(model: string): string {
-  // Subagent requests use a specific model number which Copilot doesn't support
-  if (model.startsWith("claude-sonnet-4-")) {
-    return model.replace(/^claude-sonnet-4-.*/, "claude-sonnet-4")
-  } else if (model.startsWith("claude-opus-")) {
-    return model.replace(/^claude-opus-4-.*/, "claude-opus-4")
+  // Claude Code sends versioned model names (claude-opus-4-7-20250514, claude-opus-4-7,
+  // claude-opus-4.7, claude-sonnet-4-5-20250514, etc.) that Copilot doesn't support.
+  // Normalize to base names: claude-opus-4, claude-sonnet-4, etc.
+  const match = model.match(/^(claude-[a-z]+-\d+)[\-.].*/)
+  if (match) {
+    return match[1]
   }
   return model
 }


### PR DESCRIPTION
## Summary
- Claude Code sends various versioned model names (`claude-opus-4-7`, `claude-opus-4-7-20250514`, `claude-opus-4.7`, `claude-sonnet-4-5-20250514`, etc.) that GHC Copilot doesn't support
- Replaces the per-model `startsWith` + `replace` checks with a single regex that normalizes all variants to their base name (e.g. `claude-opus-4`, `claude-sonnet-4`)
- Fixes "model_not_supported" 400 error when using Opus 4.7 (1M context) in Claude Code

## Test plan
- [ ] Test with `claude-opus-4-7` → should normalize to `claude-opus-4`
- [ ] Test with `claude-opus-4-7-20250514` → should normalize to `claude-opus-4`
- [ ] Test with `claude-opus-4.7` → should normalize to `claude-opus-4`
- [ ] Test with `claude-sonnet-4` → should pass through unchanged
- [ ] Test with `gpt-4o` → should pass through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)