### PR TITLE
feat(responses): add /v1/responses endpoint for Codex CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+`AGENTS.md` covers commands and code-style basics — read it first. This file focuses on architecture and the non-obvious behaviors that span multiple files.
+
+## Commands
+
+- `bun run dev` — watch-mode server (`src/main.ts`)
+- `bun run typecheck` — `tsc` (no emit; the build runs through tsdown)
+- `bun run lint` / `bun run lint:all` — ESLint with `@echristian/eslint-config`. A `pre-commit` hook (`simple-git-hooks` + `lint-staged`) runs `lint --fix` on staged files.
+- `bun test tests/<file>.test.ts` — single test via Bun's runner. Tests live in `tests/`, named `*.test.ts`.
+- `bun run knip` — dead-code / unused-export check
+- `bun run build` — `tsdown` bundles `src/main.ts` → `dist/main.js` (esm, node, es2022). The `bin` entry ships `dist/main.js`.
+
+Use `~/*` import alias for anything under `src/*` (configured in `tsconfig.json`).
+
+## Architecture
+
+This is a translating reverse proxy: it speaks **OpenAI** and **Anthropic** wire formats to clients, then re-shapes each request into GitHub Copilot's internal ChatCompletions shape and impersonates the VS Code Copilot Chat extension on the way out.
+
+### Request flow
+
+```
+client (Claude Code / OpenAI tool)
+  → Hono server (src/server.ts)
+    → route handler (src/routes/<api>/handler.ts)
+      → translator (Anthropic only: src/routes/messages/*-translation.ts)
+        → src/services/copilot/create-chat-completions.ts
+          → fetch → https://api.githubcopilot.com/chat/completions
+        → translator (response)
+      ← back through the same layers
+```
+
+`src/server.ts` mounts every route twice — bare (`/chat/completions`) and `/v1/`-prefixed — for compatibility with tools that assume either convention. Anthropic endpoints are only mounted under `/v1/messages`.
+
+### The Anthropic translator is the heart of the codebase
+
+`src/routes/messages/` is where most of the interesting work happens:
+
+- `non-stream-translation.ts` — `translateToOpenAI` (request) and `translateToAnthropic` (response). Both streaming and non-streaming paths share `translateToOpenAI`; the streaming path additionally uses `translateChunkToAnthropicEvents` from `stream-translation.ts`.
+- `stream-translation.ts` — chunk-by-chunk SSE translation. Maintains `AnthropicStreamState` (defined in `anthropic-types.ts`) to track `contentBlockIndex`, open/closed block state, and a `toolCalls` map that aligns OpenAI's per-tool `index` with Anthropic's per-block index. **Tool-call indices are not interchangeable between the two formats** — read the state struct before touching this code.
+- `anthropic-types.ts` — single source of truth for incoming Anthropic shapes; mirror new fields here before reading them downstream.
+- `handler.ts` — orchestrates: parses payload, calls `translateToOpenAI`, awaits manual approval / rate-limit if enabled, then either returns a JSON response or streams via `streamSSE`.
+
+When Anthropic features need to flow through to Copilot, the work is almost always: add the field to `anthropic-types.ts`, read it in `translateToOpenAI`, add it to `ChatCompletionsPayload` in `services/copilot/create-chat-completions.ts`, done. Example: `thinking_budget` forwarding.
+
+### Copilot impersonation
+
+`src/lib/api-config.ts` constructs the headers Copilot's broker checks. The `editor-version` value comes from `state.vsCodeVersion`, which is fetched live at startup by `cacheVSCodeVersion()` in `src/lib/utils.ts` — so the proxy always claims to be the latest VS Code build. `EDITOR_PLUGIN_VERSION` (`copilot-chat/0.26.7`) and `USER_AGENT` are hardcoded constants; bump them in lockstep when upstream Copilot changes its handshake. `copilotBaseUrl` switches subdomain by `accountType` (individual / business / enterprise).
+
+`create-chat-completions.ts` adds one runtime-derived header: `X-Initiator: agent` if any prior message has `role` of `assistant` or `tool`, else `user`. This affects Copilot premium-request accounting, so don't "simplify" it away.
+
+### Auth flow
+
+GitHub OAuth Device Flow → `state.githubToken` (persisted under `~/.local/share/copilot-api/`) → exchanged via `api.github.com/copilot_internal/v2/token` → `state.copilotToken` (in-memory, refreshed). All of this lives in `src/services/github/` and `src/lib/token.ts`. `state` (`src/lib/state.ts`) is a singleton object — every layer that needs auth or rate-limit config imports it directly.
+
+### CLI
+
+`citty`-based subcommands defined in `src/start.ts`, `src/auth.ts`, `src/check-usage.ts`, `src/debug.ts`, wired up in `src/main.ts`. The `start --claude-code` flag prompts for two model IDs, then writes a shell `export ...; claude` command to the clipboard via `src/lib/shell.ts`.
+
+## Fork-specific behavior
+
+This fork adds `thinking_budget` forwarding for Claude models on Copilot's CAPI path — see the "Extended Thinking" section of README.md for user-facing docs and `translateToOpenAI` for the implementation. Notably:
+
+- The translator drops `temperature` / `top_p` whenever `thinking.type === "enabled"` (Anthropic's invariant).
+- The budget is clamped to `max_tokens - 1` locally; per-model min/max clamping is left to Copilot's broker.
+- Only `thinking_budget` is forwarded — the Messages-API-only `effort` and `output_config` fields are not, because Copilot's CAPI broker rejects them.
+- Per-prompt keyword overrides (`think`, `megathink`, `ultrathink`, etc.) are detected by `detectKeywordBudget` in `non-stream-translation.ts` and act as a floor on top of `MAX_THINKING_TOKENS`; the scanner walks back past `tool_result`/`image`-only user turns so the trigger stays sticky across agentic loops, and fenced code blocks are stripped before matching.

--- a/README.md
+++ b/README.md
@@ -356,6 +356,24 @@ Notes:
 - Only Claude models on the ChatCompletions path are affected. The `effort: low|medium|high` parameter (Messages API / Responses API) is **not** forwarded — Copilot's CAPI broker doesn't accept it.
 - Run with `--verbose` to see `thinking_budget` in the translated payload log line.
 
+#### Per-prompt budget override
+
+Override the budget per-request using natural-language triggers in your prompt:
+
+| Trigger | Budget |
+|---|---|
+| `think` (at start of a line) | 4000 |
+| `think hard` / `megathink` | 10000 |
+| `think harder` / `ultrathink` | 31999 |
+
+The translator scans the most recent user message that contains text
+(skipping tool-result-only turns mid-loop), strips fenced code blocks, then
+matches. The highest-budget trigger wins. Triggers act as a **floor** —
+they raise `MAX_THINKING_TOKENS` for that request but cannot lower it, so
+a casual `think` in your prompt won't downgrade an explicit higher budget.
+The keyword is left in the prompt verbatim. The next user prompt
+re-evaluates.
+
 To dial the budget per-session, use shell aliases:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -326,6 +326,44 @@ You can find more options here: [Claude Code settings](https://docs.anthropic.co
 
 You can also read more about IDE integration here: [Add Claude Code to your IDE](https://docs.anthropic.com/en/docs/claude-code/ide-integrations)
 
+### Extended Thinking (Claude models)
+
+This fork forwards Claude's extended-thinking budget through to Copilot's broker so Claude Code can request deeper reasoning. The translator reads `thinking.budget_tokens` from the incoming Anthropic request and emits `thinking_budget` on the outgoing Copilot ChatCompletions body — the same flat field that VS Code Copilot Chat uses.
+
+Set the budget via the `MAX_THINKING_TOKENS` env var when launching Claude Code:
+
+```sh
+MAX_THINKING_TOKENS=10000 claude
+```
+
+Or persist it in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://localhost:4141",
+    "ANTHROPIC_AUTH_TOKEN": "dummy",
+    "MAX_THINKING_TOKENS": "10000"
+  }
+}
+```
+
+Notes:
+
+- The value is a **fixed budget per request**, not a ceiling. Every request burns up to that many thinking tokens, including trivial prompts — pick a value that matches your typical workload.
+- The budget is clamped to `max_tokens - 1` to satisfy Anthropic's invariant; per-model min/max clamping happens on Copilot's side.
+- When `thinking` is enabled, `temperature` and `top_p` are dropped from the outgoing payload (Anthropic forbids them with extended thinking).
+- Only Claude models on the ChatCompletions path are affected. The `effort: low|medium|high` parameter (Messages API / Responses API) is **not** forwarded — Copilot's CAPI broker doesn't accept it.
+- Run with `--verbose` to see `thinking_budget` in the translated payload log line.
+
+To dial the budget per-session, use shell aliases:
+
+```sh
+alias cc='claude'                                  # model default
+alias cct='MAX_THINKING_TOKENS=10000 claude'       # think
+alias ccu='MAX_THINKING_TOKENS=31999 claude'       # ultrathink
+```
+
 ## Running from Source
 
 The project can be run from source in several ways:

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,43 @@
+# TASKS
+
+Tracking deferred work and known limitations. New items go at the top of their section.
+
+## Backlog
+
+### Per-client isolation for parallel agents
+
+When running Claude Code (on `/v1/messages`) and Codex CLI (on `/v1/responses`)
+against the same proxy instance, the request paths themselves are independent —
+but several proxy-wide controls are still global and can cause one client to
+interfere with the other.
+
+- **`--rate-limit <seconds>` is global.** Both clients share the cooldown
+  window. A heavy Claude Code session can starve Codex requests and vice
+  versa. Investigate either per-route windows or per-client headers (e.g.,
+  `x-client-id`) to scope the gate.
+- **`--manual` (request approval) queues globally.** Both clients' requests
+  hit the same stdin prompt. Workable but awkward when two agents fire
+  concurrently. Consider scoping by route, or labelling the prompt with the
+  originating endpoint.
+- **`MAX_THINKING_TOKENS` is process-wide.** It applies to every Claude
+  thinking-eligible request regardless of which client sent it. The
+  per-prompt keyword override (already shipped) and the Codex `reasoning.effort`
+  → `thinking_budget` mapping (in design) both layer on top of it, but there
+  is no way to set "10000 for Claude Code, 0 for Codex". A per-route default
+  env var (e.g., `MAX_THINKING_TOKENS_MESSAGES`,
+  `MAX_THINKING_TOKENS_RESPONSES`) would address this.
+
+**Workaround today:** run two proxy instances on different ports, each with
+its own `--rate-limit` / `--manual` / `MAX_THINKING_TOKENS`. Same upstream
+Copilot token in both, so GitHub abuse-detection risk is unchanged.
+
+### Codex reasoning on GPT-5 / o-series via Copilot
+
+The first cut of `/v1/responses` translates Codex requests to Copilot's
+`/chat/completions` upstream for all models. That means GPT-5 and o-series
+"reasoning" models routed through Codex lose their `reasoning.effort` —
+Copilot's chat-completions endpoint doesn't accept that field, and we drop
+it for GPT models. To restore it, we would need to add an upstream
+Responses-API client and route reasoning models there (mirroring what
+VS Code Copilot Chat does internally). Document the limitation in README
+when the initial `/v1/responses` ships.

--- a/docs/superpowers/plans/2026-04-20-per-prompt-thinking-keywords.md
+++ b/docs/superpowers/plans/2026-04-20-per-prompt-thinking-keywords.md
@@ -1,0 +1,672 @@
+# Per-Prompt Thinking Keywords Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users override `thinking_budget` per-request by typing natural-language triggers (`think`, `megathink`, `ultrathink`, etc.) into their prompt — keyword acts as a floor on top of `MAX_THINKING_TOKENS`, sticky across agentic tool loops, and resilient to common false-positive sources.
+
+**Architecture:** Add a pure detector function in `src/routes/messages/non-stream-translation.ts` that scans the most recent user-authored text turn (skipping tool_result/image-only turns), strips fenced code blocks, then matches against an ordered keyword table (highest budget first). Wire into the existing `translateToOpenAI` budget resolution with `Math.max(keywordBudget, payloadBudget)` floor semantics. Both streaming and non-streaming paths pick it up because they share `translateToOpenAI`.
+
+**Tech Stack:** TypeScript (Bun), Hono, `bun:test`, Zod (existing test infra).
+
+**Spec:** `docs/superpowers/specs/2026-04-20-per-prompt-thinking-keywords-design.md`
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `src/routes/messages/non-stream-translation.ts` | Add `THINKING_KEYWORDS`, `extractUserText`, `detectKeywordBudget`; wire into `translateToOpenAI` |
+| `tests/thinking-keywords.test.ts` | New test file — pure unit tests on `detectKeywordBudget` plus integration assertions on `translateToOpenAI` output |
+| `README.md` | Add "Per-prompt budget override" subsection under "Extended Thinking (Claude models)" |
+| `CLAUDE.md` | Add one sentence under "Fork-specific behavior" |
+
+`detectKeywordBudget` is exported alongside `translateToOpenAI` to allow fine-grained unit tests; it has no side effects.
+
+---
+
+## Task 1: Add the keyword detector (TDD)
+
+**Files:**
+- Create: `tests/thinking-keywords.test.ts`
+- Modify: `src/routes/messages/non-stream-translation.ts`
+
+This task introduces the pure `detectKeywordBudget` function. No wiring yet.
+
+- [ ] **Step 1: Write the first batch of failing tests**
+
+Create `tests/thinking-keywords.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+
+import type {
+  AnthropicMessage,
+  AnthropicUserMessage,
+} from "~/routes/messages/anthropic-types"
+
+import { detectKeywordBudget } from "../src/routes/messages/non-stream-translation"
+
+const userText = (text: string): AnthropicUserMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+})
+
+const userString = (text: string): AnthropicUserMessage => ({
+  role: "user",
+  content: text,
+})
+
+describe("detectKeywordBudget", () => {
+  test("bare `think` at start of message → 4000", () => {
+    expect(detectKeywordBudget([userText("think about this")])).toBe(4000)
+  })
+
+  test("bare `think` mid-sentence → undefined", () => {
+    expect(
+      detectKeywordBudget([userText("I think we should refactor")]),
+    ).toBeUndefined()
+  })
+
+  test("`think hard` → 10000", () => {
+    expect(detectKeywordBudget([userText("think hard about X")])).toBe(10000)
+  })
+
+  test("`megathink` anywhere → 10000", () => {
+    expect(
+      detectKeywordBudget([userText("please megathink this one")]),
+    ).toBe(10000)
+  })
+
+  test("`ultrathink` → 31999", () => {
+    expect(detectKeywordBudget([userText("ultrathink: refactor")])).toBe(31999)
+  })
+
+  test("`think harder` → 31999", () => {
+    expect(detectKeywordBudget([userText("think harder about it")])).toBe(31999)
+  })
+
+  test("highest budget wins when multiple keywords present", () => {
+    expect(
+      detectKeywordBudget([userText("think hard, then ultrathink")]),
+    ).toBe(31999)
+  })
+
+  test("no keyword → undefined", () => {
+    expect(detectKeywordBudget([userText("just do X")])).toBeUndefined()
+  })
+
+  test("substring `thinking` does not trigger (word boundary)", () => {
+    expect(
+      detectKeywordBudget([userText("thinking about it")]),
+    ).toBeUndefined()
+  })
+
+  test("string-form user content is supported", () => {
+    expect(detectKeywordBudget([userString("ultrathink please")])).toBe(31999)
+  })
+
+  test("empty messages → undefined", () => {
+    expect(detectKeywordBudget([])).toBeUndefined()
+  })
+
+  test("only assistant/system messages → undefined", () => {
+    const messages: Array<AnthropicMessage> = [
+      { role: "assistant", content: "ultrathink" },
+    ]
+    expect(detectKeywordBudget(messages)).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/thinking-keywords.test.ts`
+Expected: FAIL — `detectKeywordBudget is not a function` (or import error).
+
+- [ ] **Step 3: Implement `detectKeywordBudget` (initial pass)**
+
+In `src/routes/messages/non-stream-translation.ts`, after the existing `resolveThinkingBudget` function, add:
+
+```ts
+// Per-prompt thinking-budget keyword triggers. Compound forms (megathink,
+// ultrathink, think hard/harder) match anywhere; bare `think` requires
+// start-of-line to avoid firing on incidental "I think we should..." prose.
+const THINKING_KEYWORDS: ReadonlyArray<{ pattern: RegExp; budget: number }> = [
+  { pattern: /\b(?:think harder|ultrathink)\b/i, budget: 31999 },
+  { pattern: /\b(?:think hard|megathink)\b/i, budget: 10000 },
+  { pattern: /(?:^|\n)\s*think\b/i, budget: 4000 },
+]
+
+const FENCED_CODE_BLOCK = /```[\s\S]*?```/g
+
+function extractUserText(message: AnthropicUserMessage): string {
+  if (typeof message.content === "string") return message.content
+  return message.content
+    .filter((b): b is AnthropicTextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n")
+}
+
+export function detectKeywordBudget(
+  messages: Array<AnthropicMessage>,
+): number | undefined {
+  // Walk back to the most recent user-authored TEXT message, skipping
+  // user-role turns that contain only tool_result / image blocks (they
+  // appear after every assistant tool_use in agentic loops).
+  let text: string | undefined
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role !== "user") continue
+    const candidate = extractUserText(m)
+    if (candidate.trim().length > 0) {
+      text = candidate
+      break
+    }
+  }
+  if (text === undefined) return undefined
+
+  // Strip fenced code blocks so triggers inside code samples don't fire.
+  const scrubbed = text.replace(FENCED_CODE_BLOCK, "")
+
+  for (const { pattern, budget } of THINKING_KEYWORDS) {
+    if (pattern.test(scrubbed)) return budget
+  }
+  return undefined
+}
+```
+
+`AnthropicUserMessage`, `AnthropicMessage`, and `AnthropicTextBlock` are already imported at the top of this file — no new imports required.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/thinking-keywords.test.ts`
+Expected: PASS — all 12 tests.
+
+- [ ] **Step 5: Run lint + typecheck**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/routes/messages/non-stream-translation.ts tests/thinking-keywords.test.ts
+git commit -m "feat(messages): add thinking-budget keyword detector"
+```
+
+---
+
+## Task 2: Cover sticky-across-tool-loops behavior
+
+**Files:**
+- Modify: `tests/thinking-keywords.test.ts`
+
+This task locks in the most important Codex finding: the detector must walk past tool_result-only user turns mid agentic loop.
+
+- [ ] **Step 1: Append failing tests**
+
+Add to `tests/thinking-keywords.test.ts` inside the `describe("detectKeywordBudget", ...)` block:
+
+```ts
+  test("walks back past image-only user turn", () => {
+    const messages: Array<AnthropicMessage> = [
+      userText("ultrathink the bug"),
+      { role: "assistant", content: "ok" },
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "abc",
+            },
+          },
+        ],
+      },
+    ]
+    expect(detectKeywordBudget(messages)).toBe(31999)
+  })
+
+  test("walks back past tool_result-only user turn", () => {
+    const messages: Array<AnthropicMessage> = [
+      userText("ultrathink the refactor"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "read",
+            input: { path: "x" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool_1",
+            content: "file contents",
+          },
+        ],
+      },
+    ]
+    expect(detectKeywordBudget(messages)).toBe(31999)
+  })
+
+  test("sticky across multi-step tool loop", () => {
+    const messages: Array<AnthropicMessage> = [
+      userText("ultrathink: implement feature X"),
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "t1", name: "read", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "t1", content: "..." },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "t2", name: "edit", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "t2", content: "ok" },
+        ],
+      },
+    ]
+    expect(detectKeywordBudget(messages)).toBe(31999)
+  })
+
+  test("all user turns are tool_result/image only → undefined", () => {
+    const messages: Array<AnthropicMessage> = [
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "t1", content: "x" },
+        ],
+      },
+    ]
+    expect(detectKeywordBudget(messages)).toBeUndefined()
+  })
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test tests/thinking-keywords.test.ts`
+Expected: PASS — these should already pass against the Task 1 implementation, since the walk-back loop was implemented correctly the first time. If any fail, fix the detector before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/thinking-keywords.test.ts
+git commit -m "test(messages): cover sticky keyword across agentic tool loops"
+```
+
+---
+
+## Task 3: Cover fenced-code-block stripping
+
+**Files:**
+- Modify: `tests/thinking-keywords.test.ts`
+
+- [ ] **Step 1: Append tests**
+
+Add inside the same `describe` block:
+
+```ts
+  test("`think` inside fenced code block does not trigger", () => {
+    const text = "review this:\n```\nthink about state\n```\n"
+    expect(detectKeywordBudget([userText(text)])).toBeUndefined()
+  })
+
+  test("`ultrathink` inside fenced code block does NOT trigger", () => {
+    // Compound triggers can match anywhere in the message, but fenced code
+    // is stripped first — so they don't fire from inside ``` blocks.
+    const text = "review this:\n```\nultrathink everything\n```\n"
+    expect(detectKeywordBudget([userText(text)])).toBeUndefined()
+  })
+
+  test("trigger outside code block still fires when other text is fenced", () => {
+    const text = "ultrathink this:\n```\njust some code\n```\n"
+    expect(detectKeywordBudget([userText(text)])).toBe(31999)
+  })
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test tests/thinking-keywords.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/thinking-keywords.test.ts
+git commit -m "test(messages): cover fenced-code-block keyword stripping"
+```
+
+---
+
+## Task 4: Wire keyword budget into `translateToOpenAI` with floor semantics
+
+**Files:**
+- Modify: `src/routes/messages/non-stream-translation.ts:29-56` (the `translateToOpenAI` function)
+- Modify: `tests/thinking-keywords.test.ts`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Append to `tests/thinking-keywords.test.ts`:
+
+```ts
+import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
+
+import { translateToOpenAI } from "../src/routes/messages/non-stream-translation"
+
+const buildPayload = (
+  overrides: Partial<AnthropicMessagesPayload> = {},
+): AnthropicMessagesPayload => ({
+  model: "claude-sonnet-4",
+  max_tokens: 64000,
+  messages: [userText("hello")],
+  ...overrides,
+})
+
+describe("translateToOpenAI thinking budget", () => {
+  test("no keyword, no payload thinking → no thinking_budget", () => {
+    const out = translateToOpenAI(buildPayload())
+    expect(out.thinking_budget).toBeUndefined()
+  })
+
+  test("keyword only → uses keyword budget", () => {
+    const out = translateToOpenAI(
+      buildPayload({ messages: [userText("ultrathink: refactor")] }),
+    )
+    expect(out.thinking_budget).toBe(31999)
+    expect(out.temperature).toBeUndefined()
+    expect(out.top_p).toBeUndefined()
+  })
+
+  test("payload only → uses payload budget", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        thinking: { type: "enabled", budget_tokens: 8000 },
+      }),
+    )
+    expect(out.thinking_budget).toBe(8000)
+  })
+
+  test("floor: keyword < payload → payload wins", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        messages: [userText("think about it")],
+        thinking: { type: "enabled", budget_tokens: 10000 },
+      }),
+    )
+    expect(out.thinking_budget).toBe(10000)
+  })
+
+  test("floor: keyword > payload → keyword wins", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        messages: [userText("ultrathink the bug")],
+        thinking: { type: "enabled", budget_tokens: 4000 },
+      }),
+    )
+    expect(out.thinking_budget).toBe(31999)
+  })
+
+  test("max_tokens clamps the budget", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        max_tokens: 500,
+        messages: [userText("ultrathink")],
+      }),
+    )
+    expect(out.thinking_budget).toBe(499)
+  })
+
+  test("thinking on drops temperature and top_p", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        messages: [userText("ultrathink")],
+        temperature: 0.7,
+        top_p: 0.9,
+      }),
+    )
+    expect(out.temperature).toBeUndefined()
+    expect(out.top_p).toBeUndefined()
+  })
+
+  test("no thinking → temperature and top_p preserved", () => {
+    const out = translateToOpenAI(
+      buildPayload({ temperature: 0.7, top_p: 0.9 }),
+    )
+    expect(out.temperature).toBe(0.7)
+    expect(out.top_p).toBe(0.9)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify the keyword-related ones fail**
+
+Run: `bun test tests/thinking-keywords.test.ts`
+Expected: the "keyword only", "floor" and "max_tokens clamps" tests for keyword paths FAIL — `thinking_budget` is undefined because wiring is not in place yet.
+
+- [ ] **Step 3: Modify `translateToOpenAI` to read keyword budget with floor semantics**
+
+In `src/routes/messages/non-stream-translation.ts`, replace the current top of `translateToOpenAI`:
+
+```ts
+export function translateToOpenAI(
+  payload: AnthropicMessagesPayload,
+): ChatCompletionsPayload {
+  const thinkingBudget =
+    payload.thinking?.type === "enabled" ?
+      resolveThinkingBudget(payload.thinking.budget_tokens, payload.max_tokens)
+    : undefined
+  const thinkingOn = thinkingBudget !== undefined
+```
+
+with:
+
+```ts
+export function translateToOpenAI(
+  payload: AnthropicMessagesPayload,
+): ChatCompletionsPayload {
+  const keywordBudget = detectKeywordBudget(payload.messages)
+  const payloadBudget =
+    payload.thinking?.type === "enabled" ?
+      payload.thinking.budget_tokens
+    : undefined
+
+  // Floor semantics: keyword can raise an explicit MAX_THINKING_TOKENS
+  // budget but must never silently lower it.
+  const requestedBudget =
+    keywordBudget !== undefined && payloadBudget !== undefined ?
+      Math.max(keywordBudget, payloadBudget)
+    : (keywordBudget ?? payloadBudget)
+
+  const thinkingBudget = resolveThinkingBudget(
+    requestedBudget,
+    payload.max_tokens,
+  )
+  const thinkingOn = thinkingBudget !== undefined
+```
+
+The rest of the function body (the `return { ... }` block) is unchanged.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `bun test`
+Expected: PASS — including pre-existing `tests/anthropic-request.test.ts` and `tests/anthropic-response.test.ts`.
+
+- [ ] **Step 5: Run lint + typecheck**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/routes/messages/non-stream-translation.ts tests/thinking-keywords.test.ts
+git commit -m "feat(messages): wire keyword thinking budget with floor semantics"
+```
+
+---
+
+## Task 5: Live smoke test
+
+**Files:** none modified — manual verification only.
+
+- [ ] **Step 1: Start the dev server**
+
+Run in one terminal: `bun run dev`
+Expected: server listening on `http://localhost:4141`. Leave running.
+
+- [ ] **Step 2: Send a baseline request (no keyword, no `thinking`)**
+
+```bash
+curl -sS http://localhost:4141/v1/messages \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "claude-sonnet-4",
+    "max_tokens": 1024,
+    "messages": [{"role":"user","content":"say hi"}]
+  }' | jq -r '.content[0].text' | head -3
+```
+
+Expected: a brief greeting; in the dev server logs, the translated payload line should NOT contain `thinking_budget`.
+
+- [ ] **Step 3: Send a request with `ultrathink`**
+
+```bash
+curl -sS http://localhost:4141/v1/messages \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "claude-sonnet-4",
+    "max_tokens": 4096,
+    "messages": [{"role":"user","content":"ultrathink: explain how a B-tree works"}]
+  }' | jq '.usage'
+```
+
+Expected: response succeeds; dev server log shows `thinking_budget: 31999` (clamped to 4095 because `max_tokens=4096`). Response usage may include thinking tokens depending on model.
+
+Run with `bun run dev` started via `--verbose` if the budget isn't visible in the log:
+`bun run dev -- start --verbose` (or restart with `bun src/main.ts start --verbose`).
+
+- [ ] **Step 4: Verify floor semantics with a payload-budget request**
+
+This requires Claude Code to be the client (it sends `thinking.budget_tokens`). As a curl proxy, simulate:
+
+```bash
+curl -sS http://localhost:4141/v1/messages \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "claude-sonnet-4",
+    "max_tokens": 16384,
+    "thinking": {"type":"enabled","budget_tokens":10000},
+    "messages": [{"role":"user","content":"think about this small problem"}]
+  }' | jq '.usage'
+```
+
+Expected: dev-server log shows `thinking_budget: 10000` (NOT 4000 — floor wins). This is the key Codex-finding fix to verify in vivo.
+
+- [ ] **Step 5: Stop the dev server**
+
+Ctrl-C the `bun run dev` terminal. Nothing to commit.
+
+---
+
+## Task 6: Documentation updates
+
+**Files:**
+- Modify: `README.md:329` (after the existing "Extended Thinking (Claude models)" section)
+- Modify: `CLAUDE.md:64-68` (fork-specific behavior section)
+
+- [ ] **Step 1: Add the README subsection**
+
+In `README.md`, find the line `To dial the budget per-session, use shell aliases:` and insert this block ABOVE it (so it lands between the "Notes:" bullet list and the shell-alias snippet):
+
+```markdown
+#### Per-prompt budget override
+
+Override the budget per-request using natural-language triggers in your prompt:
+
+| Trigger | Budget |
+|---|---|
+| `think` (at start of a line) | 4000 |
+| `think hard` / `megathink` | 10000 |
+| `think harder` / `ultrathink` | 31999 |
+
+The translator scans the most recent user message that contains text
+(skipping tool-result-only turns mid-loop), strips fenced code blocks, then
+matches. The highest-budget trigger wins. Triggers act as a **floor** —
+they raise `MAX_THINKING_TOKENS` for that request but cannot lower it, so
+a casual `think` in your prompt won't downgrade an explicit higher budget.
+The keyword is left in the prompt verbatim. The next user prompt
+re-evaluates.
+
+```
+
+- [ ] **Step 2: Add the CLAUDE.md sentence**
+
+In `CLAUDE.md`, in the "Fork-specific behavior" section, append a fourth bullet under the existing list:
+
+```markdown
+- Per-prompt keyword overrides (`think`, `megathink`, `ultrathink`, etc.) are detected by `detectKeywordBudget` in `non-stream-translation.ts` and act as a floor on top of `MAX_THINKING_TOKENS`; the scanner walks back past `tool_result`/`image`-only user turns so the trigger stays sticky across agentic loops, and fenced code blocks are stripped before matching.
+```
+
+- [ ] **Step 3: Verify formatting**
+
+Run: `bun run lint:all`
+Expected: no errors. (Markdown isn't linted by ESLint, but this catches accidental TS file touches.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "docs: per-prompt thinking-budget keyword overrides"
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `bun test`
+Expected: PASS — all suites including `thinking-keywords.test.ts` (~20 tests).
+
+- [ ] **Step 2: Run typecheck, lint, knip**
+
+Run: `bun run typecheck && bun run lint && bun run knip`
+Expected: no errors. `knip` should not flag `detectKeywordBudget` (it's used inside the same module — tests import it but that's fine; if knip flags it, exporting is still desired for testability).
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run: `git log --oneline origin/master..HEAD` (or `git log --oneline -10` if no upstream)
+Expected: 6 commits in order — detector, sticky tests, code-block tests, wiring, docs, plus any test-only commits from Tasks 2/3.
+
+- [ ] **Step 4: No commit needed.**
+
+---
+
+## Out of scope (per spec — do NOT implement)
+
+- Custom keyword config via env var
+- Numeric override syntax like `[think:N]`
+- Stripping keywords from forwarded text
+- Dedicated logging when a keyword fires (verbose log already shows `thinking_budget`)

--- a/docs/superpowers/specs/2026-04-20-codex-responses-api-design.md
+++ b/docs/superpowers/specs/2026-04-20-codex-responses-api-design.md
@@ -1,338 +1,241 @@
 # `/v1/responses` for Codex CLI
 
-**Status:** Approved
+**Status:** Draft
 **Date:** 2026-04-20
 **Issue:** https://github.com/xiaocheng139/copilot-api/issues/1
 
 ## Goal
 
-Add an OpenAI Responses-API-compatible endpoint at `/v1/responses` so Codex
-CLI (v0.87+) can talk to this proxy the same way Claude Code talks to
-`/v1/messages`. Both clients should be runnable in parallel against a single
-proxy instance, each on its own native wire format, with all upstream
-traffic continuing to flow through GitHub Copilot's `chat/completions`
-broker.
+Let Codex CLI use this proxy at the same time Claude Code already does,
+against a single instance, each on its native wire format. Both clients
+route through Copilot's `chat/completions` broker upstream.
 
-The first cut translates Codex Responses-API requests into Copilot's
-`chat/completions` shape (the same shape `/v1/messages` already uses) and
-back-translates the streaming chat-completion deltas into a synthetic
-Responses-API SSE event stream. Per-route isolation of `--rate-limit`,
-`--manual`, and `MAX_THINKING_TOKENS`, and the upstream Responses-API client
-needed to preserve `reasoning.effort` for GPT-5 / o-series models, are
-deferred to TASKS.md.
+Add `/v1/responses` that translates to/from `chat/completions`,
+mirroring the existing `src/routes/messages/` translator.
 
 ## Background
 
-Codex CLI exclusively uses OpenAI's Responses API on its model path —
-`build_responses_request` in `codex-rs/core/src/client.rs` always sets
-`stream: true` and posts to `/v1/responses`. The Responses API differs from
-chat-completions in three substantive ways:
-
-1. **Request shape.** Top-level `instructions` (system prompt), an `input[]`
-   array of mixed item types (`message`, `function_call`,
-   `function_call_output`, `reasoning`, `custom_tool_call*`), flat tool
-   definitions (`{type, name, description, strict, parameters}` rather than
-   `{type: "function", function: {…}}`), and a `reasoning: {effort, summary}`
-   block.
-2. **Streaming protocol.** The client reconstructs the assistant turn from
-   `response.output_item.done` events; `response.completed` is the only
-   required terminator; `response.output_text.delta` is cosmetic.
-3. **Reasoning.** `reasoning.effort` is a string enum
-   (`"minimal"|"low"|"medium"|"high"`) rather than the numeric
-   `thinking_budget` we already forward for Claude.
-
-The repo already has the translation pattern we need (`src/routes/messages/`
-maps Anthropic Messages → chat-completions and back). We mirror it.
+Codex CLI v0.87+ only speaks the OpenAI Responses API
+(`build_responses_request` in `codex-rs/core/src/client.rs` always posts
+to `/v1/responses` with `stream: true`). Copilot's broker doesn't speak
+Responses, so we translate down to `chat/completions` going up and
+synthesize Responses SSE events coming back.
 
 ## Architecture
 
-New directory `src/routes/responses/`:
+New `src/routes/responses/` mirroring `src/routes/messages/`:
 
 | File | Responsibility |
 |---|---|
-| `route.ts` | Hono route definition; wires path + handler. |
-| `handler.ts` | Orchestrates: parse payload, translate request, await `--manual`/`--rate-limit`, call `createChatCompletions`, stream or buffer the response, translate to Responses-API SSE. |
-| `responses-types.ts` | TypeScript types for the incoming Codex Responses-API payload (`ResponsesRequest`, `ResponsesInputItem`, `ResponsesTool`, etc.). Single source of truth for the wire shape. |
-| `request-translation.ts` | Pure translator: `ResponsesRequest` → `ChatCompletionsPayload`. |
-| `stream-translation.ts` | State machine that consumes chat-completion SSE chunks and emits Responses-API SSE events. |
+| `route.ts` | Hono route. |
+| `handler.ts` | Parses payload, calls translator, awaits `--manual` / `--rate-limit`, calls `createChatCompletions`, streams via `streamSSE`. |
+| `responses-types.ts` | Incoming Responses payload types. |
+| `request-translation.ts` | `ResponsesRequest → ChatCompletionsPayload`. |
+| `stream-translation.ts` | Chat-completions SSE chunks → Responses SSE events. |
 
-Mounted in `src/server.ts` at both `/responses` and `/v1/responses`,
-matching the existing dual-mount convention. Anthropic stays on
-`/v1/messages` only (clients always use the `/v1/` prefix there); we follow
-the same convention for the OpenAI-compatible Responses path so Codex's
-default base URL (`http://host:port/v1`) just works.
-
-The handler reuses `createChatCompletions`, `awaitApproval`,
-`checkRateLimit`, the `state` singleton, and the existing `streamSSE`
-helper. No new auth, header, or upstream-client code is needed for the
-first cut.
+Mounted at `/responses` and `/v1/responses`. Reuses
+`createChatCompletions`, `awaitApproval`, `checkRateLimit`, `state`,
+`streamSSE`.
 
 ## Request translation
 
-`request-translation.ts` exports `translateResponsesToChatCompletions`. It
-converts Codex's Responses-API payload into the chat-completions shape
-already expected by `services/copilot/create-chat-completions.ts`.
-
-### Top-level fields
-
-| Codex Responses field | Chat-completions destination |
+| Codex field | Chat-completions destination |
 |---|---|
-| `model` | `model` (verbatim; `translateModelName` from `messages/non-stream-translation.ts` is **not** applied — Codex sends real GitHub-Copilot model IDs already) |
-| `instructions` | Prepended as a `{role: "system", content: instructions}` message |
-| `input[]` | Translated item-by-item into `messages[]` (see below) |
-| `tools[]` | Wrapped from flat `{type: "function", name, …}` into nested `{type: "function", function: {name, description, parameters}}`. Non-`function` types (`custom`, `local_shell`, `web_search`) are dropped with a single verbose-log warning per request. |
-| `tool_choice` | Forwarded verbatim when it's `"auto"` / `"required"` / `"none"`; the `{type: "function", name}` form is rewrapped into `{type: "function", function: {name}}`. |
-| `parallel_tool_calls` | Forwarded as `parallel_tool_calls`. |
-| `reasoning.effort` | Translated to `thinking_budget` for Claude models only (see below). For non-Claude models the field is dropped and a verbose-log warning notes the limitation. |
-| `max_output_tokens` | Mapped to `max_tokens`. |
-| `metadata.user_id` | Forwarded as `user`. |
-| `temperature`, `top_p` | Forwarded verbatim, subject to the existing thinking-on drop rule. |
-| `stream` | Forwarded; Codex always sends `true`. The handler's stream/non-stream branch keys off this. |
+| `model` | `model` (verbatim) |
+| `instructions` | `{role: "system", content: instructions}` prepended |
+| `input[]` | `messages[]` (see below) |
+| `tools[]` | Lowered to function tools (see "Tools") |
+| `tool_choice` | Forwarded; see "Tools" |
+| `parallel_tool_calls` | Forwarded |
+| `reasoning.effort` | Mapped to `thinking_budget` for Claude (see "Reasoning") |
+| `max_output_tokens` | `max_tokens` |
+| `temperature`, `top_p` | Forwarded (subject to thinking-on drop rule) |
+| `metadata.user_id` | `user` |
+| `stream` | Forwarded |
 
-Dropped on the floor (Responses-API-only fields with no chat-completions
-analogue, none required by Copilot's broker): `store`, `include`,
-`service_tier`, `prompt_cache_key`, `safety_identifier`, `client_metadata`,
-`text` (output-format hints), `reasoning.summary`, `reasoning.encrypted_content`,
-`previous_response_id`, `truncation`, `background`. A single verbose-log
-line lists which of these fields were present and dropped, for debugging.
+`previous_response_id`, `store: true`, `background: true` → `400
+unsupported_responses_field`. We don't store responses; silently
+dropping these would lose continuation context.
+
+Other unenumerated keys are dropped with a verbose log.
 
 ### `input[]` → `messages[]`
 
-Codex's `input[]` is a heterogeneous array. We map each item type:
-
-| Codex item type | Chat-completions message |
+| Codex item | Message |
 |---|---|
-| `{type: "message", role, content: [{type: "input_text"\|"output_text"\|"input_image", …}]}` | `{role, content}` where multi-part text becomes a joined string and `input_image` becomes a `{type: "image_url", image_url: {url}}` part (matching the existing image handling in `messages/non-stream-translation.ts`). |
-| `{type: "function_call", call_id, name, arguments}` | Appended as / merged into a preceding `{role: "assistant", tool_calls: [{id: call_id, type: "function", function: {name, arguments}}]}`. Adjacent function-call items addressed to the same assistant turn are coalesced into one message's `tool_calls[]`. |
-| `{type: "function_call_output", call_id, output}` | `{role: "tool", tool_call_id: call_id, content: output}` (output stringified if not already a string). |
-| `{type: "reasoning", …}` | **Dropped.** Copilot's chat-completions broker does not accept reasoning items in the message log. |
-| `{type: "custom_tool_call"\|"custom_tool_call_output"\|"local_shell_call"\|"local_shell_call_output"\|"web_search_call"}` | **Dropped** with one verbose-log warning per request type. These tool families are deferred. |
+| `{type: "message", role, content: [...]}` | `{role, content}`. `input_text`/`output_text` join as text; `input_image` → `{type: "image_url", image_url: {url}}` (same as `messages/non-stream-translation.ts`) |
+| `{type: "function_call", call_id, name, arguments}` | Coalesced into `{role: "assistant", tool_calls: [...]}` |
+| `{type: "function_call_output", call_id, output}` | `{role: "tool", tool_call_id: call_id, content: output}` |
+| `{type: "local_shell_call", call_id, action}` | Function-tool call named `__cp_local_shell` with `arguments = JSON.stringify(action)` |
+| `{type: "local_shell_call_output", …}` | Same as `function_call_output` |
+| `{type: "custom_tool_call", call_id, name, input}` | Function-tool call using the synthetic id minted for the matching `custom` tool, `arguments = JSON.stringify({input})` |
+| `{type: "custom_tool_call_output", …}` | Same as `function_call_output` |
+| `{type: "reasoning", …}` | Dropped |
+| anything else | Dropped with a verbose log |
 
-The synthesized `messages[]` then runs through the same downstream pipe
-`/v1/messages` already uses — including the per-prompt thinking keyword
-detector. `detectKeywordBudget` already takes `Array<AnthropicMessage>` but
-operates only on the `role: "user"` text content, which is shape-compatible
-with our synthesized chat messages once we widen the input type (or, more
-cleanly, lift the detector to operate on a minimal `{role, content}` shape
-and re-export it for both translators). Implementation detail to settle
-during plan-writing; behavior is unchanged.
+Consecutive tool-call items before the next `*_output` merge into one
+assistant turn.
 
-### `reasoning.effort` → `thinking_budget`
+The synthesized `messages[]` runs through the same pipe `/v1/messages`
+uses, including `detectKeywordBudget` (lifted to a `{role, content}`
+shape and re-exported).
 
-Mapping (Claude models only; identified by model-name prefix `claude-`):
+## Tools
 
-| `effort` | `thinking_budget` |
+Codex sends `function`, `local_shell`, `custom`. All three lower to
+chat-completions function tools.
+
+| Codex tool def | Lowered to |
 |---|---|
-| `"minimal"` | undefined (no thinking) |
+| `{type: "function", name, description, parameters, strict}` | `{type: "function", function: {name, description, parameters, strict}}` |
+| `{type: "local_shell"}` | Function tool named `__cp_local_shell`, parameters = LocalShellAction schema |
+| `{type: "custom", name, description}` | Function tool named `__cp_custom_<n>` (per-request counter), parameters = `{type: "object", properties: {input: {type: "string"}}, required: ["input"]}` |
+
+The translator keeps a per-request `syntheticId → {family,
+originalName?}` map so the response translator can raise calls back to
+their native shape (`local_shell_call` / `custom_tool_call`) and recover
+the original `custom` tool name verbatim.
+
+`__cp_` is reserved. Any user `function`/`custom` whose `name` starts
+with `__cp_` (in `tools[]` or in historical `input[]` `function_call`
+items) → `400 reserved_tool_name`. Prevents a user-defined `local_shell`
+function from being raised as a privileged shell call.
+
+### Raising and fallback
+
+When the upstream model emits a function call:
+- Name in the synthetic-id map → raise to `local_shell_call` /
+  `custom_tool_call`.
+- Plain user `function` → emit as `function_call`.
+- Args fail to parse or fail shape validation:
+  - Plain function: pass the raw args string through; Codex surfaces it.
+  - Synthetic id: emit `response.failed` with
+    `code=upstream_malformed_tool_arguments`. Don't echo a `__cp_*` name
+    back to Codex (next turn would reject it).
+- `__cp_*` name **not** in the map (upstream hallucination / version
+  skew): `response.failed` with `code=undeclared_synthetic_tool`.
+
+Shape validation:
+- `__cp_local_shell` → `LocalShellAction` (object with
+  `command: string[]`, optional `workdir`, `env`, `timeout_ms`).
+- `__cp_custom_<n>` → `{input: string}`.
+
+### `tool_choice`
+
+| Codex value | Chat-completions value |
+|---|---|
+| `"auto"`, `"none"`, `"required"` | Same |
+| `{type: "function", name}` | `{type: "function", function: {name}}` |
+| `{type: "allowed_tools", tools, mode}` | Resolve each entry against declared `tools[]`. Entries are `"local_shell"` or `{type: "function" \| "custom", name}`. Anything that doesn't resolve → `400 unknown_tool_in_choice`. Empty resolved set → `400 empty_allowed_tools`. Forward the resolved list with the requested `mode`. |
+
+`web_search` is unsupported. If `allowed_tools` references it → `400
+unsupported_tool_in_choice`. Otherwise drop the def with a verbose log
+and let the model recover.
+
+## Reasoning effort
+
+Claude models (id starts with `claude-`):
+
+| `effort` | `thinking_budget` anchor |
+|---|---|
+| `"minimal"` | undefined |
 | `"low"` | 4000 |
 | `"medium"` | 10000 |
 | `"high"` | 31999 |
 
-These are the same anchor values as the keyword detector's `think` /
-`think hard` / `think harder` tiers, which keeps the dial consistent across
-both client paths. The keyword detector still runs on top with floor
-semantics, so a Codex prompt with `effort: "low"` plus `ultrathink` in the
-text gets `31999` — same rule as the Claude Code path.
+Anchor → keyword floor (`detectKeywordBudget`) → single
+`resolveThinkingBudget` clamp against `max_output_tokens - 1`.
 
-For non-Claude models the field is dropped. The GPT-5 / o-series
-reasoning-loss case is documented in TASKS.md and called out in the README.
+Non-Claude models: `reasoning.effort` is dropped with a verbose log.
+Real `reasoning_effort` pass-through to GPT-5 / o-series is follow-up
+once we confirm Copilot's broker accepts the field.
 
-## Streaming response translation
+## Response translation
 
-`stream-translation.ts` exports `translateChunksToResponsesEvents`, a
-generator (or `ReadableStream` transformer) that consumes the
-chat-completion SSE chunks emitted by `createChatCompletions` and produces
-Responses-API SSE events.
+Chat-completions deltas → Responses SSE events. Minimum set
+`process_sse` (in `codex-rs/core/src/client.rs`) parses — verify against
+the parser before merge:
 
-### State
+- `response.created` — once at start, `response.id = "resp_" + nanoid`,
+  reused in every subsequent event and the final envelope.
+- `response.output_item.added` — new assistant message or tool call.
+- `response.output_text.delta` — streaming text.
+- `response.output_item.done` — finalizes each item; this is what Codex
+  parses to reconstruct the turn.
+- `response.completed` — terminator with `usage` and final `status`.
 
-```ts
-interface ResponsesStreamState {
-  responseId: string          // generated once, reused on every event
-  model: string               // echoed from upstream
-  textBuffer: string          // accumulated assistant text
-  toolCalls: Map<number, {    // keyed by upstream OpenAI tool-call index
-    id: string
-    name: string
-    argumentsBuffer: string
-  }>
-  finishReason: string | null
-  usage: ChatCompletionUsage | null
-  emittedCreated: boolean
-}
-```
+Each item gets `id` = nanoid with a type prefix (`msg_`, `fc_`, `lsc_`,
+`ctc_`) and a 0-indexed `output_index`.
 
-### Event sequence
+### `finish_reason` → `status`
 
-For each upstream SSE chunk:
+| Upstream | Status | Notes |
+|---|---|---|
+| `stop` | `completed` | |
+| `tool_calls` | `completed` | Tool calls live in `output[]` |
+| `length` | `incomplete` | `incomplete_details: {reason: "max_output_tokens"}` |
+| `content_filter` | `incomplete` | `incomplete_details: {reason: "content_filter"}` |
+| `null` + `[DONE]` | `completed` | Normal end |
+| `null` no `[DONE]`, no accumulated content | n/a | Emit `response.failed code=stream_interrupted`; no `response.completed` |
+| `null` no `[DONE]`, partial content | `incomplete` | Validate the accumulated set: every item parseable + shape-valid → emit `output_item.done` for each in order, then `response.completed status=incomplete` (synthetics raise normally). Any item malformed → emit only `response.failed code=stream_interrupted_malformed_tool_arguments`, flush nothing. (Codex acts on `output_item.done`, so partial flush of a parallel turn could execute one privileged call alongside a malformed sibling.) |
+| anything else | `incomplete` | `incomplete_details: {reason: "unknown", upstream_reason: "<value>"}` |
 
-1. On the **first chunk**, emit `response.created` with a synthesized
-   response envelope (`id`, `model`, `status: "in_progress"`,
-   `output: []`, etc.). Set `emittedCreated = true`.
-2. For each `delta.content` text fragment, append to `textBuffer` and emit
-   `response.output_text.delta` with the fragment. Cosmetic — Codex
-   reconstructs from the eventual `output_item.done`, but emitting deltas
-   keeps the UX live.
-3. For each `delta.tool_calls[]` entry, look it up in `toolCalls` by
-   `index`; create the entry on first sight (capturing `id` and `name`),
-   append `function.arguments` to its buffer. No streaming
-   `function_call_arguments.delta` event in the first cut — Codex parses the
-   final `output_item.done`.
-4. When a chunk has `finish_reason`, store it. Don't terminate yet —
-   the upstream stream may still send a usage chunk.
-5. When the upstream stream ends:
-   - If `textBuffer` is non-empty, emit `response.output_item.done` with
-     `{type: "message", role: "assistant", content: [{type: "output_text", text: textBuffer}]}`.
-   - For each entry in `toolCalls`, emit `response.output_item.done` with
-     `{type: "function_call", call_id, name, arguments: argumentsBuffer}`.
-   - Emit `response.completed` with the full response envelope: `output[]`
-     populated, `status: "completed"` (or the mapped status from
-     `finishReason`), and `usage` mapped from the chat-completion usage
-     block (`prompt_tokens`/`completion_tokens` → `input_tokens`/
-     `output_tokens`, cached tokens → `input_tokens_details.cached_tokens`).
+## Errors
 
-### Error mapping
+Upstream HTTP → Responses error envelope (body wraps `{error: {type,
+message, code?}}`):
 
-When `createChatCompletions` throws an HTTP error mid-translation, emit a
-`response.failed` event with an error code mapped from the upstream HTTP
-status:
-
-| Upstream status | Responses-API error code |
+| Upstream | Type |
 |---|---|
-| 401, 403 | `usage_not_included` |
-| 429 | `rate_limit_exceeded` |
-| 400 with `context_length_exceeded` body marker | `context_length_exceeded` |
-| 5xx | `server_error` |
-| anything else | `server_error` (default) with the upstream message |
+| 400 | `invalid_request_error` |
+| 401 | `authentication_error` |
+| 403 | `permission_error` |
+| 404 | `not_found_error` |
+| 408 / 504 | `timeout_error` |
+| 429 | `rate_limit_error` |
+| 5xx | `api_error` |
 
-If we haven't emitted `response.created` yet (failure in the request
-translator or before the upstream stream opens), respond with a non-stream
-HTTP error in the standard Responses-API error envelope instead, since SSE
-events without a prior `response.created` confuse Codex.
+Boundary: validation, hard-rejected fields, reserved names,
+`--manual`/`--rate-limit` denial, and upstream failure before the first
+chunk → non-stream HTTP envelope. After `response.created` is emitted
+→ `response.failed` SSE event then close.
 
-## Wiring, headers, tests, docs
+## Tests
 
-### Hono wiring
+Style of `tests/anthropic-*.test.ts`:
 
-`src/routes/responses/route.ts` defines the Hono app and exports it.
-`src/server.ts` mounts it at `/responses` and `/v1/responses`. The handler
-mirrors `messages/handler.ts`:
-
-1. Parse and validate the body via the new types.
-2. Run `--manual` approval (if enabled) and `--rate-limit` (if enabled),
-   reusing the global helpers. **Note:** these stay process-wide for now;
-   Codex and Claude Code share the same gates. TASKS.md tracks the per-route
-   isolation work.
-3. Translate request → call `createChatCompletions` → translate response.
-4. Branch on `payload.stream` (always true for current Codex, but support
-   non-stream too for completeness and so future tooling/tests can hit the
-   endpoint without SSE plumbing).
-
-### `X-Initiator` header
-
-`create-chat-completions.ts` derives `X-Initiator: agent` when any prior
-message has `role` of `assistant` or `tool`. Our synthesized `messages[]`
-already contains those roles when Codex sends `function_call` /
-`function_call_output` items, so the header is computed correctly with no
-change. **Do not "simplify" this header derivation away** — it affects
-Copilot premium-request accounting.
-
-### Tests
-
-New file `tests/responses-translation.test.ts`. Roughly 22 cases:
-
-**Request translation (`translateResponsesToChatCompletions`):**
-
-- Plain user message → single user chat message
-- `instructions` → leading system message
-- `input_image` → `{type: "image_url", …}` content part
-- `function_call` followed by `function_call_output` → assistant
-  `tool_calls` + tool message with matching `tool_call_id`
-- Two adjacent `function_call` items → coalesced into one assistant turn's
-  `tool_calls[]`
-- `reasoning` item → dropped, doesn't appear in messages
-- `custom_tool_call` / `local_shell_call` / `web_search_call` → dropped,
-  warning logged once
-- Tools: flat `{type: "function", name, …}` → nested wrapping
-- Tools: `{type: "custom"}` dropped
-- `tool_choice: "auto"` / `"required"` / `"none"` → forwarded
-- `tool_choice: {type: "function", name: "X"}` → rewrapped
-- `reasoning.effort: "minimal"` on Claude model → no `thinking_budget`
-- `reasoning.effort: "low"` on Claude model → `thinking_budget=4000`
-- `reasoning.effort: "high"` on Claude model → `thinking_budget=31999`
-- `reasoning.effort` on non-Claude model → dropped
-- `reasoning.effort: "low"` + user text containing `ultrathink` → final
-  `thinking_budget=31999` (floor semantics)
-- `metadata.user_id` → `user`
-- `max_output_tokens` → `max_tokens`
-- Dropped fields (`store`, `include`, `service_tier`, etc.) don't appear in
-  output
-
-**Stream translation (`translateChunksToResponsesEvents`):**
-
-- Single text-only assistant chunk → `response.created` →
-  `response.output_text.delta` → `response.output_item.done` (message) →
-  `response.completed` with usage
-- Tool-call chunks → `response.created` → `response.output_item.done`
-  (function_call) → `response.completed`
-- Mixed text + tool-call chunks → both `output_item.done` events emitted in
-  text-then-tool order
-- Error during stream → `response.failed` with mapped error code
-
-### Live smoke test
-
-After implementation, point a real Codex CLI at the running proxy
-(`OPENAI_BASE_URL=http://localhost:<port>/v1 codex`) and run a tool-using
-prompt end-to-end. Verify that text and at least one tool call round-trip,
-matching the procedure already used to validate the `thinking_budget`
-patch. Capture the verbose log to confirm `X-Initiator` flips to `agent`
-on the second turn.
-
-### Documentation
-
-Add a "OpenAI Responses API (Codex CLI)" subsection to README.md showing:
-
-- The endpoint URL.
-- A minimal Codex `~/.codex/config.toml` snippet pointing
-  `model_provider.openai.base_url` at the proxy.
-- The reasoning.effort → thinking_budget mapping table (Claude only).
-- A note that GPT-5 / o-series reasoning is currently lost on this path
-  (linking to TASKS.md) and that `--rate-limit` / `--manual` /
-  `MAX_THINKING_TOKENS` are still process-wide.
-
-Add one bullet to `CLAUDE.md`'s "Fork-specific behavior" section noting the
-new translator pair.
+- **Request translation:** message types, tool lowering, `tool_choice`
+  (`allowed_tools` resolution, unknown / empty / `web_search` → 400),
+  reasoning effort mapping (with clamp under low `max_output_tokens`),
+  metadata, coalescing, image parts.
+- **Stream translation:** text only, single tool call, parallel tool
+  calls, local-shell raise, custom-tool raise, malformed-args plain
+  fallback, malformed-args synthetic → `response.failed`, undeclared
+  `__cp_*` → `response.failed`, every `finish_reason` row above
+  (including parallel-turn transport-cut where one item is valid and
+  one is malformed → must emit only `response.failed`, not
+  `output_item.done`).
+- **Pre-stream errors:** unsupported continuation fields, reserved tool
+  name (in `tools[]` and in historical `input[]`), `--manual` /
+  `--rate-limit` denial, upstream non-OK before first chunk.
+- **Smoke:** `bun test` plus manual `codex --model claude-sonnet-4-5
+  --base-url http://localhost:4141 "explain this repo"` alongside a
+  concurrent Claude Code session.
 
 ## Files touched
 
-- `src/routes/responses/route.ts` (new)
-- `src/routes/responses/handler.ts` (new)
-- `src/routes/responses/responses-types.ts` (new)
-- `src/routes/responses/request-translation.ts` (new)
-- `src/routes/responses/stream-translation.ts` (new)
-- `src/server.ts` — mount the new route at `/responses` and `/v1/responses`
-- `src/routes/messages/non-stream-translation.ts` — minor: lift the role/
-  content shape that `detectKeywordBudget` accepts, or re-export a
-  scanner that takes `{role, content}` so both translators reuse it
-  unchanged. (Settle exact mechanism in the implementation plan.)
-- `tests/responses-translation.test.ts` (new) — ~22 test cases
-- `README.md` — new subsection
-- `CLAUDE.md` — one bullet
+- `src/routes/responses/*` — new (5 files above).
+- `src/server.ts` — mount at `/responses` and `/v1/responses`.
+- `src/routes/messages/non-stream-translation.ts` — export
+  `detectKeywordBudget` with a `{role, content}` parameter shape.
+- `tests/responses-*.test.ts` — new.
+- `README.md` — short "Codex CLI" section.
 
-## Out of scope (deferred to TASKS.md or follow-ups)
+## Out of scope
 
-- **Upstream Responses API client.** Routing GPT-5 / o-series through
-  Copilot's actual Responses upstream so `reasoning.effort` survives.
-  Currently tracked in TASKS.md as "Codex reasoning on GPT-5 / o-series via
-  Copilot."
-- **Per-route isolation of `--rate-limit`, `--manual`, `MAX_THINKING_TOKENS`.**
-  Tracked in TASKS.md as "Per-client isolation for parallel agents."
-- **WebSocket / push paths.** Codex doesn't use them; not implemented.
-- **`custom_tool_call`, `local_shell_call`, `web_search_call` tool
-  families.** Dropped with a warning. Codex degrades to "tool not
-  available" on those.
-- **`previous_response_id` / `background` / `store`-backed continuations.**
-  Codex doesn't rely on server-side response storage in our setup.
-- **Streaming `function_call_arguments.delta` events.** First cut emits the
-  arguments only via the final `output_item.done`, which is sufficient for
-  Codex; per-token argument deltas are a UX polish.
+- OpenAI Responses upstream client (would let GPT-5/o-series reasoning
+  round-trip and let us honor `previous_response_id` / `store` /
+  `background` instead of rejecting). Tracked in TASKS.md.
+- Per-route isolation of `--rate-limit`, `--manual`,
+  `MAX_THINKING_TOKENS`. Tracked in TASKS.md.
+- Web search tools.

--- a/docs/superpowers/specs/2026-04-20-codex-responses-api-design.md
+++ b/docs/superpowers/specs/2026-04-20-codex-responses-api-design.md
@@ -1,0 +1,338 @@
+# `/v1/responses` for Codex CLI
+
+**Status:** Approved
+**Date:** 2026-04-20
+**Issue:** https://github.com/xiaocheng139/copilot-api/issues/1
+
+## Goal
+
+Add an OpenAI Responses-API-compatible endpoint at `/v1/responses` so Codex
+CLI (v0.87+) can talk to this proxy the same way Claude Code talks to
+`/v1/messages`. Both clients should be runnable in parallel against a single
+proxy instance, each on its own native wire format, with all upstream
+traffic continuing to flow through GitHub Copilot's `chat/completions`
+broker.
+
+The first cut translates Codex Responses-API requests into Copilot's
+`chat/completions` shape (the same shape `/v1/messages` already uses) and
+back-translates the streaming chat-completion deltas into a synthetic
+Responses-API SSE event stream. Per-route isolation of `--rate-limit`,
+`--manual`, and `MAX_THINKING_TOKENS`, and the upstream Responses-API client
+needed to preserve `reasoning.effort` for GPT-5 / o-series models, are
+deferred to TASKS.md.
+
+## Background
+
+Codex CLI exclusively uses OpenAI's Responses API on its model path —
+`build_responses_request` in `codex-rs/core/src/client.rs` always sets
+`stream: true` and posts to `/v1/responses`. The Responses API differs from
+chat-completions in three substantive ways:
+
+1. **Request shape.** Top-level `instructions` (system prompt), an `input[]`
+   array of mixed item types (`message`, `function_call`,
+   `function_call_output`, `reasoning`, `custom_tool_call*`), flat tool
+   definitions (`{type, name, description, strict, parameters}` rather than
+   `{type: "function", function: {…}}`), and a `reasoning: {effort, summary}`
+   block.
+2. **Streaming protocol.** The client reconstructs the assistant turn from
+   `response.output_item.done` events; `response.completed` is the only
+   required terminator; `response.output_text.delta` is cosmetic.
+3. **Reasoning.** `reasoning.effort` is a string enum
+   (`"minimal"|"low"|"medium"|"high"`) rather than the numeric
+   `thinking_budget` we already forward for Claude.
+
+The repo already has the translation pattern we need (`src/routes/messages/`
+maps Anthropic Messages → chat-completions and back). We mirror it.
+
+## Architecture
+
+New directory `src/routes/responses/`:
+
+| File | Responsibility |
+|---|---|
+| `route.ts` | Hono route definition; wires path + handler. |
+| `handler.ts` | Orchestrates: parse payload, translate request, await `--manual`/`--rate-limit`, call `createChatCompletions`, stream or buffer the response, translate to Responses-API SSE. |
+| `responses-types.ts` | TypeScript types for the incoming Codex Responses-API payload (`ResponsesRequest`, `ResponsesInputItem`, `ResponsesTool`, etc.). Single source of truth for the wire shape. |
+| `request-translation.ts` | Pure translator: `ResponsesRequest` → `ChatCompletionsPayload`. |
+| `stream-translation.ts` | State machine that consumes chat-completion SSE chunks and emits Responses-API SSE events. |
+
+Mounted in `src/server.ts` at both `/responses` and `/v1/responses`,
+matching the existing dual-mount convention. Anthropic stays on
+`/v1/messages` only (clients always use the `/v1/` prefix there); we follow
+the same convention for the OpenAI-compatible Responses path so Codex's
+default base URL (`http://host:port/v1`) just works.
+
+The handler reuses `createChatCompletions`, `awaitApproval`,
+`checkRateLimit`, the `state` singleton, and the existing `streamSSE`
+helper. No new auth, header, or upstream-client code is needed for the
+first cut.
+
+## Request translation
+
+`request-translation.ts` exports `translateResponsesToChatCompletions`. It
+converts Codex's Responses-API payload into the chat-completions shape
+already expected by `services/copilot/create-chat-completions.ts`.
+
+### Top-level fields
+
+| Codex Responses field | Chat-completions destination |
+|---|---|
+| `model` | `model` (verbatim; `translateModelName` from `messages/non-stream-translation.ts` is **not** applied — Codex sends real GitHub-Copilot model IDs already) |
+| `instructions` | Prepended as a `{role: "system", content: instructions}` message |
+| `input[]` | Translated item-by-item into `messages[]` (see below) |
+| `tools[]` | Wrapped from flat `{type: "function", name, …}` into nested `{type: "function", function: {name, description, parameters}}`. Non-`function` types (`custom`, `local_shell`, `web_search`) are dropped with a single verbose-log warning per request. |
+| `tool_choice` | Forwarded verbatim when it's `"auto"` / `"required"` / `"none"`; the `{type: "function", name}` form is rewrapped into `{type: "function", function: {name}}`. |
+| `parallel_tool_calls` | Forwarded as `parallel_tool_calls`. |
+| `reasoning.effort` | Translated to `thinking_budget` for Claude models only (see below). For non-Claude models the field is dropped and a verbose-log warning notes the limitation. |
+| `max_output_tokens` | Mapped to `max_tokens`. |
+| `metadata.user_id` | Forwarded as `user`. |
+| `temperature`, `top_p` | Forwarded verbatim, subject to the existing thinking-on drop rule. |
+| `stream` | Forwarded; Codex always sends `true`. The handler's stream/non-stream branch keys off this. |
+
+Dropped on the floor (Responses-API-only fields with no chat-completions
+analogue, none required by Copilot's broker): `store`, `include`,
+`service_tier`, `prompt_cache_key`, `safety_identifier`, `client_metadata`,
+`text` (output-format hints), `reasoning.summary`, `reasoning.encrypted_content`,
+`previous_response_id`, `truncation`, `background`. A single verbose-log
+line lists which of these fields were present and dropped, for debugging.
+
+### `input[]` → `messages[]`
+
+Codex's `input[]` is a heterogeneous array. We map each item type:
+
+| Codex item type | Chat-completions message |
+|---|---|
+| `{type: "message", role, content: [{type: "input_text"\|"output_text"\|"input_image", …}]}` | `{role, content}` where multi-part text becomes a joined string and `input_image` becomes a `{type: "image_url", image_url: {url}}` part (matching the existing image handling in `messages/non-stream-translation.ts`). |
+| `{type: "function_call", call_id, name, arguments}` | Appended as / merged into a preceding `{role: "assistant", tool_calls: [{id: call_id, type: "function", function: {name, arguments}}]}`. Adjacent function-call items addressed to the same assistant turn are coalesced into one message's `tool_calls[]`. |
+| `{type: "function_call_output", call_id, output}` | `{role: "tool", tool_call_id: call_id, content: output}` (output stringified if not already a string). |
+| `{type: "reasoning", …}` | **Dropped.** Copilot's chat-completions broker does not accept reasoning items in the message log. |
+| `{type: "custom_tool_call"\|"custom_tool_call_output"\|"local_shell_call"\|"local_shell_call_output"\|"web_search_call"}` | **Dropped** with one verbose-log warning per request type. These tool families are deferred. |
+
+The synthesized `messages[]` then runs through the same downstream pipe
+`/v1/messages` already uses — including the per-prompt thinking keyword
+detector. `detectKeywordBudget` already takes `Array<AnthropicMessage>` but
+operates only on the `role: "user"` text content, which is shape-compatible
+with our synthesized chat messages once we widen the input type (or, more
+cleanly, lift the detector to operate on a minimal `{role, content}` shape
+and re-export it for both translators). Implementation detail to settle
+during plan-writing; behavior is unchanged.
+
+### `reasoning.effort` → `thinking_budget`
+
+Mapping (Claude models only; identified by model-name prefix `claude-`):
+
+| `effort` | `thinking_budget` |
+|---|---|
+| `"minimal"` | undefined (no thinking) |
+| `"low"` | 4000 |
+| `"medium"` | 10000 |
+| `"high"` | 31999 |
+
+These are the same anchor values as the keyword detector's `think` /
+`think hard` / `think harder` tiers, which keeps the dial consistent across
+both client paths. The keyword detector still runs on top with floor
+semantics, so a Codex prompt with `effort: "low"` plus `ultrathink` in the
+text gets `31999` — same rule as the Claude Code path.
+
+For non-Claude models the field is dropped. The GPT-5 / o-series
+reasoning-loss case is documented in TASKS.md and called out in the README.
+
+## Streaming response translation
+
+`stream-translation.ts` exports `translateChunksToResponsesEvents`, a
+generator (or `ReadableStream` transformer) that consumes the
+chat-completion SSE chunks emitted by `createChatCompletions` and produces
+Responses-API SSE events.
+
+### State
+
+```ts
+interface ResponsesStreamState {
+  responseId: string          // generated once, reused on every event
+  model: string               // echoed from upstream
+  textBuffer: string          // accumulated assistant text
+  toolCalls: Map<number, {    // keyed by upstream OpenAI tool-call index
+    id: string
+    name: string
+    argumentsBuffer: string
+  }>
+  finishReason: string | null
+  usage: ChatCompletionUsage | null
+  emittedCreated: boolean
+}
+```
+
+### Event sequence
+
+For each upstream SSE chunk:
+
+1. On the **first chunk**, emit `response.created` with a synthesized
+   response envelope (`id`, `model`, `status: "in_progress"`,
+   `output: []`, etc.). Set `emittedCreated = true`.
+2. For each `delta.content` text fragment, append to `textBuffer` and emit
+   `response.output_text.delta` with the fragment. Cosmetic — Codex
+   reconstructs from the eventual `output_item.done`, but emitting deltas
+   keeps the UX live.
+3. For each `delta.tool_calls[]` entry, look it up in `toolCalls` by
+   `index`; create the entry on first sight (capturing `id` and `name`),
+   append `function.arguments` to its buffer. No streaming
+   `function_call_arguments.delta` event in the first cut — Codex parses the
+   final `output_item.done`.
+4. When a chunk has `finish_reason`, store it. Don't terminate yet —
+   the upstream stream may still send a usage chunk.
+5. When the upstream stream ends:
+   - If `textBuffer` is non-empty, emit `response.output_item.done` with
+     `{type: "message", role: "assistant", content: [{type: "output_text", text: textBuffer}]}`.
+   - For each entry in `toolCalls`, emit `response.output_item.done` with
+     `{type: "function_call", call_id, name, arguments: argumentsBuffer}`.
+   - Emit `response.completed` with the full response envelope: `output[]`
+     populated, `status: "completed"` (or the mapped status from
+     `finishReason`), and `usage` mapped from the chat-completion usage
+     block (`prompt_tokens`/`completion_tokens` → `input_tokens`/
+     `output_tokens`, cached tokens → `input_tokens_details.cached_tokens`).
+
+### Error mapping
+
+When `createChatCompletions` throws an HTTP error mid-translation, emit a
+`response.failed` event with an error code mapped from the upstream HTTP
+status:
+
+| Upstream status | Responses-API error code |
+|---|---|
+| 401, 403 | `usage_not_included` |
+| 429 | `rate_limit_exceeded` |
+| 400 with `context_length_exceeded` body marker | `context_length_exceeded` |
+| 5xx | `server_error` |
+| anything else | `server_error` (default) with the upstream message |
+
+If we haven't emitted `response.created` yet (failure in the request
+translator or before the upstream stream opens), respond with a non-stream
+HTTP error in the standard Responses-API error envelope instead, since SSE
+events without a prior `response.created` confuse Codex.
+
+## Wiring, headers, tests, docs
+
+### Hono wiring
+
+`src/routes/responses/route.ts` defines the Hono app and exports it.
+`src/server.ts` mounts it at `/responses` and `/v1/responses`. The handler
+mirrors `messages/handler.ts`:
+
+1. Parse and validate the body via the new types.
+2. Run `--manual` approval (if enabled) and `--rate-limit` (if enabled),
+   reusing the global helpers. **Note:** these stay process-wide for now;
+   Codex and Claude Code share the same gates. TASKS.md tracks the per-route
+   isolation work.
+3. Translate request → call `createChatCompletions` → translate response.
+4. Branch on `payload.stream` (always true for current Codex, but support
+   non-stream too for completeness and so future tooling/tests can hit the
+   endpoint without SSE plumbing).
+
+### `X-Initiator` header
+
+`create-chat-completions.ts` derives `X-Initiator: agent` when any prior
+message has `role` of `assistant` or `tool`. Our synthesized `messages[]`
+already contains those roles when Codex sends `function_call` /
+`function_call_output` items, so the header is computed correctly with no
+change. **Do not "simplify" this header derivation away** — it affects
+Copilot premium-request accounting.
+
+### Tests
+
+New file `tests/responses-translation.test.ts`. Roughly 22 cases:
+
+**Request translation (`translateResponsesToChatCompletions`):**
+
+- Plain user message → single user chat message
+- `instructions` → leading system message
+- `input_image` → `{type: "image_url", …}` content part
+- `function_call` followed by `function_call_output` → assistant
+  `tool_calls` + tool message with matching `tool_call_id`
+- Two adjacent `function_call` items → coalesced into one assistant turn's
+  `tool_calls[]`
+- `reasoning` item → dropped, doesn't appear in messages
+- `custom_tool_call` / `local_shell_call` / `web_search_call` → dropped,
+  warning logged once
+- Tools: flat `{type: "function", name, …}` → nested wrapping
+- Tools: `{type: "custom"}` dropped
+- `tool_choice: "auto"` / `"required"` / `"none"` → forwarded
+- `tool_choice: {type: "function", name: "X"}` → rewrapped
+- `reasoning.effort: "minimal"` on Claude model → no `thinking_budget`
+- `reasoning.effort: "low"` on Claude model → `thinking_budget=4000`
+- `reasoning.effort: "high"` on Claude model → `thinking_budget=31999`
+- `reasoning.effort` on non-Claude model → dropped
+- `reasoning.effort: "low"` + user text containing `ultrathink` → final
+  `thinking_budget=31999` (floor semantics)
+- `metadata.user_id` → `user`
+- `max_output_tokens` → `max_tokens`
+- Dropped fields (`store`, `include`, `service_tier`, etc.) don't appear in
+  output
+
+**Stream translation (`translateChunksToResponsesEvents`):**
+
+- Single text-only assistant chunk → `response.created` →
+  `response.output_text.delta` → `response.output_item.done` (message) →
+  `response.completed` with usage
+- Tool-call chunks → `response.created` → `response.output_item.done`
+  (function_call) → `response.completed`
+- Mixed text + tool-call chunks → both `output_item.done` events emitted in
+  text-then-tool order
+- Error during stream → `response.failed` with mapped error code
+
+### Live smoke test
+
+After implementation, point a real Codex CLI at the running proxy
+(`OPENAI_BASE_URL=http://localhost:<port>/v1 codex`) and run a tool-using
+prompt end-to-end. Verify that text and at least one tool call round-trip,
+matching the procedure already used to validate the `thinking_budget`
+patch. Capture the verbose log to confirm `X-Initiator` flips to `agent`
+on the second turn.
+
+### Documentation
+
+Add a "OpenAI Responses API (Codex CLI)" subsection to README.md showing:
+
+- The endpoint URL.
+- A minimal Codex `~/.codex/config.toml` snippet pointing
+  `model_provider.openai.base_url` at the proxy.
+- The reasoning.effort → thinking_budget mapping table (Claude only).
+- A note that GPT-5 / o-series reasoning is currently lost on this path
+  (linking to TASKS.md) and that `--rate-limit` / `--manual` /
+  `MAX_THINKING_TOKENS` are still process-wide.
+
+Add one bullet to `CLAUDE.md`'s "Fork-specific behavior" section noting the
+new translator pair.
+
+## Files touched
+
+- `src/routes/responses/route.ts` (new)
+- `src/routes/responses/handler.ts` (new)
+- `src/routes/responses/responses-types.ts` (new)
+- `src/routes/responses/request-translation.ts` (new)
+- `src/routes/responses/stream-translation.ts` (new)
+- `src/server.ts` — mount the new route at `/responses` and `/v1/responses`
+- `src/routes/messages/non-stream-translation.ts` — minor: lift the role/
+  content shape that `detectKeywordBudget` accepts, or re-export a
+  scanner that takes `{role, content}` so both translators reuse it
+  unchanged. (Settle exact mechanism in the implementation plan.)
+- `tests/responses-translation.test.ts` (new) — ~22 test cases
+- `README.md` — new subsection
+- `CLAUDE.md` — one bullet
+
+## Out of scope (deferred to TASKS.md or follow-ups)
+
+- **Upstream Responses API client.** Routing GPT-5 / o-series through
+  Copilot's actual Responses upstream so `reasoning.effort` survives.
+  Currently tracked in TASKS.md as "Codex reasoning on GPT-5 / o-series via
+  Copilot."
+- **Per-route isolation of `--rate-limit`, `--manual`, `MAX_THINKING_TOKENS`.**
+  Tracked in TASKS.md as "Per-client isolation for parallel agents."
+- **WebSocket / push paths.** Codex doesn't use them; not implemented.
+- **`custom_tool_call`, `local_shell_call`, `web_search_call` tool
+  families.** Dropped with a warning. Codex degrades to "tool not
+  available" on those.
+- **`previous_response_id` / `background` / `store`-backed continuations.**
+  Codex doesn't rely on server-side response storage in our setup.
+- **Streaming `function_call_arguments.delta` events.** First cut emits the
+  arguments only via the final `output_item.done`, which is sufficient for
+  Codex; per-token argument deltas are a UX polish.

--- a/docs/superpowers/specs/2026-04-20-per-prompt-thinking-keywords-design.md
+++ b/docs/superpowers/specs/2026-04-20-per-prompt-thinking-keywords-design.md
@@ -1,0 +1,176 @@
+# Per-Prompt Thinking Budget via Keyword Triggers
+
+**Status:** Approved
+**Date:** 2026-04-20
+
+## Goal
+
+Let users override the `thinking_budget` for a single request from the prompt
+itself, mirroring Claude Code's original natural-language convention. Behavior
+is sticky-per-task naturally and resets on the next user prompt.
+
+This solves the gap left by the existing `MAX_THINKING_TOKENS` env var, which
+is a process-scoped fixed budget — there's no way to dial it up or down
+per-prompt without restarting Claude Code.
+
+## Behavior
+
+### Keyword → budget mapping
+
+Case-insensitive, word-boundary matched.
+
+| Keyword | Budget |
+|---|---|
+| `think` | 4000 |
+| `think hard`, `megathink` | 10000 |
+| `think harder`, `ultrathink` | 31999 |
+
+### Scan target
+
+Only the **last `user` message** in `payload.messages[]`. Concatenates all
+`text` blocks (or the `string` form). Ignores `tool_result`, `image`, and
+other non-text blocks.
+
+This naturally produces sticky-per-task behavior: in Claude Code's agentic
+loop, the original user message stays in `messages[]` across tool-use turns,
+so the keyword keeps firing for the duration of that task. As soon as the
+user types a fresh prompt, the new message becomes the last user message and
+re-evaluates.
+
+### Match rule
+
+If multiple keywords appear in the scanned text, **highest budget wins**. The
+keyword table is iterated high → low and returns on first match.
+
+### Precedence over Claude Code's payload
+
+If a keyword matches, its budget **overrides**
+`payload.thinking.budget_tokens` for that request. If no keyword matches,
+fall through to existing behavior (use whatever Claude Code sent, including
+the env-driven `MAX_THINKING_TOKENS`).
+
+### No keyword stripping
+
+The user's message text is forwarded verbatim. The model sees the trigger
+word in the prompt; this is harmless (and arguably reinforcing) and avoids
+edge cases around stripping inside code blocks or quoted text.
+
+## Implementation
+
+One new function and a 3-line wiring change in
+`src/routes/messages/non-stream-translation.ts`. No other files in `src/`
+require modification — `anthropic-types.ts` already declares `thinking`,
+`create-chat-completions.ts` already declares `thinking_budget`,
+`stream-translation.ts` shares the request translator with the non-stream
+path.
+
+```ts
+const THINKING_KEYWORDS: ReadonlyArray<{ pattern: RegExp; budget: number }> = [
+  { pattern: /\b(?:think harder|ultrathink)\b/i, budget: 31999 },
+  { pattern: /\b(?:think hard|megathink)\b/i,    budget: 10000 },
+  { pattern: /\bthink\b/i,                        budget: 4000  },
+]
+
+function detectKeywordBudget(messages: Array<AnthropicMessage>): number | undefined {
+  const lastUser = [...messages].reverse().find((m) => m.role === "user")
+  if (!lastUser) return undefined
+
+  const text =
+    typeof lastUser.content === "string"
+      ? lastUser.content
+      : lastUser.content
+          .filter((b): b is AnthropicTextBlock => b.type === "text")
+          .map((b) => b.text)
+          .join("\n")
+
+  for (const { pattern, budget } of THINKING_KEYWORDS) {
+    if (pattern.test(text)) return budget
+  }
+  return undefined
+}
+```
+
+Wired into `translateToOpenAI`:
+
+```ts
+const keywordBudget = detectKeywordBudget(payload.messages)
+const requestedBudget =
+  keywordBudget ??
+  (payload.thinking?.type === "enabled" ? payload.thinking.budget_tokens : undefined)
+
+const thinkingBudget = resolveThinkingBudget(requestedBudget, payload.max_tokens)
+const thinkingOn = thinkingBudget !== undefined
+```
+
+The existing `resolveThinkingBudget` (clamp to `max_tokens - 1`) and the
+existing `temperature` / `top_p` drop logic are reused unchanged.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| `max_tokens` smaller than requested budget | `resolveThinkingBudget` clamps to `max_tokens - 1`. `ultrathink` with `max_tokens=500` → `thinking_budget=499`. |
+| Keyword inside a code block / quoted text | Triggers (no stripping). Documented as intentional. |
+| No `user` messages (only system/assistant) | Returns `undefined`; falls through to existing behavior. |
+| Claude Code already sent `thinking.budget_tokens` AND keyword matches | Keyword wins. |
+| Last user message has only images / tool_results | Joined text is empty; no match; falls through. |
+| Streaming and non-streaming paths | Both share `translateToOpenAI`; both get the feature. |
+
+## Testing
+
+Unit tests in `tests/non-stream-translation.test.ts` (or a new file if that
+doesn't exist — to be checked at implementation time):
+
+| Test | Assertion |
+|---|---|
+| `"please think about this"` | budget = 4000 |
+| `"think hard about X"` | budget = 10000 |
+| `"ultrathink: refactor"` | budget = 31999 |
+| `"think hard, then ultrathink"` | budget = 31999 (highest wins) |
+| `"do X"` (no keyword) | budget = whatever payload.thinking sent (or undefined) |
+| `"thinking about it"` (substring) | budget = undefined (word boundary) |
+| `payload.thinking.budget_tokens=5000` + prompt has `ultrathink` | budget = 31999 (override) |
+| `max_tokens=500` + `ultrathink` | budget = 499 (clamp) |
+| Last user msg = image only; prior user msg has `think` | budget = undefined (only last scanned) |
+
+Plus a live smoke test against the running server using `curl`, matching the
+pattern used to verify the original `thinking_budget` patch.
+
+## Documentation
+
+Add a "Per-prompt budget override" sub-subsection under "Extended Thinking
+(Claude models)" in `README.md`:
+
+> ### Per-prompt budget override
+>
+> Override the budget per-request using natural-language triggers in your prompt:
+>
+> | Trigger | Budget |
+> |---|---|
+> | `think` | 4000 |
+> | `think hard` / `megathink` | 10000 |
+> | `think harder` / `ultrathink` | 31999 |
+>
+> The translator scans the last user message; the highest-budget match wins;
+> the keyword is left in the prompt verbatim. Triggers override
+> `MAX_THINKING_TOKENS` for that request only — the next user prompt
+> re-evaluates.
+
+Add one sentence to `CLAUDE.md` in the fork-specific section noting keyword
+override.
+
+## Files touched
+
+- `src/routes/messages/non-stream-translation.ts` — add `THINKING_KEYWORDS`,
+  `detectKeywordBudget`, and 3-line wiring in `translateToOpenAI`
+- `tests/non-stream-translation.test.ts` (or new file) — 9 new test cases
+- `README.md` — sub-subsection on per-prompt override
+- `CLAUDE.md` — one sentence in fork-specific section
+
+## Out of scope (YAGNI)
+
+- Custom keyword config via env var
+- Numeric override syntax like `[think:N]`
+- Stripping keywords from forwarded text
+- Dedicated logging when a keyword fires (verbose log already shows
+  `thinking_budget`, which is sufficient)

--- a/docs/superpowers/specs/2026-04-20-per-prompt-thinking-keywords-design.md
+++ b/docs/superpowers/specs/2026-04-20-per-prompt-thinking-keywords-design.md
@@ -27,33 +27,66 @@ Case-insensitive, word-boundary matched.
 
 ### Scan target
 
-Only the **last `user` message** in `payload.messages[]`. Concatenates all
-`text` blocks (or the `string` form). Ignores `tool_result`, `image`, and
-other non-text blocks.
+The **most recent `user` message that contains text content** in
+`payload.messages[]`. Concatenates all `text` blocks (or the `string` form)
+of that message. Ignores `tool_result`, `image`, and other non-text blocks.
+User messages whose content is *only* `tool_result` / `image` blocks (i.e.
+have no text) are **skipped** — the scan walks backwards until it finds a
+real user-authored text turn, or hits the start of `messages[]`.
 
-This naturally produces sticky-per-task behavior: in Claude Code's agentic
-loop, the original user message stays in `messages[]` across tool-use turns,
-so the keyword keeps firing for the duration of that task. As soon as the
-user types a fresh prompt, the new message becomes the last user message and
-re-evaluates.
+**Why skip tool-result turns:** in Anthropic's agentic loop, after each
+`assistant` `tool_use`, Claude Code sends the tool output back as a
+`user`-role message containing only `tool_result` blocks. If the scanner
+naively took the literal "last user message" it would see only tool output,
+the keyword would silently stop firing mid-task, and the budget would drop
+back to the default. Walking back to the most recent user-authored text
+preserves sticky-per-task behavior across arbitrarily long tool loops. As
+soon as the user types a fresh prompt, that new message is the most recent
+text-bearing user turn and re-evaluates.
 
 ### Match rule
 
 If multiple keywords appear in the scanned text, **highest budget wins**. The
 keyword table is iterated high → low and returns on first match.
 
-### Precedence over Claude Code's payload
+To avoid false positives from untrusted content (pasted issues, file
+contents, model output the user is asking the model to review, etc.), the
+keyword must appear in one of these positions:
 
-If a keyword matches, its budget **overrides**
-`payload.thinking.budget_tokens` for that request. If no keyword matches,
-fall through to existing behavior (use whatever Claude Code sent, including
-the env-driven `MAX_THINKING_TOKENS`).
+- **Anywhere** for the unambiguous compound triggers: `megathink`,
+  `ultrathink`, `think hard`, `think harder`. These are coined / rare enough
+  that incidental occurrences are negligible.
+- **At the start of a line** (after optional whitespace) for the bare
+  `think` trigger. This matches natural usage (`think about X`,
+  `think: refactor Y`) while skipping `think` buried inside a pasted
+  paragraph or code comment.
+
+Fenced code blocks (text between triple backticks) are stripped before
+matching, so `think` inside a code sample does not trigger.
+
+### Precedence: floor, not override
+
+The keyword budget acts as a **floor**, not an unconditional override:
+
+```
+finalBudget = max(keywordBudget ?? 0, payloadBudget ?? 0)
+```
+
+So `MAX_THINKING_TOKENS=10000` plus a prompt containing the bare word
+`think` (which would map to 4000) yields a final budget of **10000** — the
+casual keyword cannot silently downgrade an explicit higher budget. But
+`MAX_THINKING_TOKENS=4000` plus `ultrathink` yields **31999**, which is the
+intended dial-up case.
+
+If neither side requested a budget, no thinking is enabled (existing
+behavior).
 
 ### No keyword stripping
 
 The user's message text is forwarded verbatim. The model sees the trigger
-word in the prompt; this is harmless (and arguably reinforcing) and avoids
-edge cases around stripping inside code blocks or quoted text.
+word in the prompt; this is harmless (and arguably reinforcing). The
+position-based match rule above means keyword stripping is unnecessary even
+for the bare `think` trigger.
 
 ## Implementation
 
@@ -65,38 +98,63 @@ require modification — `anthropic-types.ts` already declares `thinking`,
 path.
 
 ```ts
+// Compound triggers match anywhere; bare `think` only at start of a line.
 const THINKING_KEYWORDS: ReadonlyArray<{ pattern: RegExp; budget: number }> = [
-  { pattern: /\b(?:think harder|ultrathink)\b/i, budget: 31999 },
-  { pattern: /\b(?:think hard|megathink)\b/i,    budget: 10000 },
-  { pattern: /\bthink\b/i,                        budget: 4000  },
+  { pattern: /\b(?:think harder|ultrathink)\b/i,  budget: 31999 },
+  { pattern: /\b(?:think hard|megathink)\b/i,     budget: 10000 },
+  { pattern: /(?:^|\n)\s*think\b/i,               budget: 4000  },
 ]
 
-function detectKeywordBudget(messages: Array<AnthropicMessage>): number | undefined {
-  const lastUser = [...messages].reverse().find((m) => m.role === "user")
-  if (!lastUser) return undefined
+const FENCED_CODE_BLOCK = /```[\s\S]*?```/g
 
-  const text =
-    typeof lastUser.content === "string"
-      ? lastUser.content
-      : lastUser.content
-          .filter((b): b is AnthropicTextBlock => b.type === "text")
-          .map((b) => b.text)
-          .join("\n")
+function extractUserText(message: AnthropicUserMessage): string {
+  if (typeof message.content === "string") return message.content
+  return message.content
+    .filter((b): b is AnthropicTextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n")
+}
+
+function detectKeywordBudget(
+  messages: Array<AnthropicMessage>,
+): number | undefined {
+  // Walk back to the most recent user-authored TEXT message, skipping
+  // user-role turns that contain only tool_result / image blocks (these
+  // appear after every assistant tool_use in agentic loops).
+  let text: string | undefined
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role !== "user") continue
+    const candidate = extractUserText(m)
+    if (candidate.trim().length > 0) {
+      text = candidate
+      break
+    }
+  }
+  if (text === undefined) return undefined
+
+  // Strip fenced code blocks so triggers inside code samples don't fire.
+  const scrubbed = text.replace(FENCED_CODE_BLOCK, "")
 
   for (const { pattern, budget } of THINKING_KEYWORDS) {
-    if (pattern.test(text)) return budget
+    if (pattern.test(scrubbed)) return budget
   }
   return undefined
 }
 ```
 
-Wired into `translateToOpenAI`:
+Wired into `translateToOpenAI` (floor semantics — keyword raises, never
+lowers):
 
 ```ts
 const keywordBudget = detectKeywordBudget(payload.messages)
+const payloadBudget =
+  payload.thinking?.type === "enabled" ? payload.thinking.budget_tokens : undefined
+
 const requestedBudget =
-  keywordBudget ??
-  (payload.thinking?.type === "enabled" ? payload.thinking.budget_tokens : undefined)
+  keywordBudget !== undefined && payloadBudget !== undefined
+    ? Math.max(keywordBudget, payloadBudget)
+    : (keywordBudget ?? payloadBudget)
 
 const thinkingBudget = resolveThinkingBudget(requestedBudget, payload.max_tokens)
 const thinkingOn = thinkingBudget !== undefined
@@ -110,10 +168,14 @@ existing `temperature` / `top_p` drop logic are reused unchanged.
 | Case | Behavior |
 |---|---|
 | `max_tokens` smaller than requested budget | `resolveThinkingBudget` clamps to `max_tokens - 1`. `ultrathink` with `max_tokens=500` → `thinking_budget=499`. |
-| Keyword inside a code block / quoted text | Triggers (no stripping). Documented as intentional. |
-| No `user` messages (only system/assistant) | Returns `undefined`; falls through to existing behavior. |
-| Claude Code already sent `thinking.budget_tokens` AND keyword matches | Keyword wins. |
-| Last user message has only images / tool_results | Joined text is empty; no match; falls through. |
+| Keyword inside a fenced code block | Stripped before matching; does not trigger. |
+| Bare `think` mid-paragraph (e.g. `"I think we should..."`) | Does not trigger — bare `think` requires start-of-line. |
+| `megathink` / `ultrathink` mid-paragraph or in pasted content | Triggers (compound forms are unambiguous and rare). Documented as intentional; if the user is reviewing untrusted text containing these literal words, budget will spike. |
+| No `user` messages, or all user messages are tool_result/image only | Returns `undefined`; falls through to existing behavior. |
+| Last user turn = tool_result (mid agentic loop), prior user turn has `ultrathink` | Scanner walks back to the prior user-authored text turn → triggers. Sticky-per-task preserved. |
+| `MAX_THINKING_TOKENS=10000` + prompt has bare `think` (4000) | Floor semantics → final budget = 10000. Casual keyword cannot downgrade. |
+| `MAX_THINKING_TOKENS=4000` + prompt has `ultrathink` (31999) | Floor semantics → final budget = 31999. Dial-up works. |
+| Last user message has only images / tool_results | Joined text is empty; scanner walks back further; if no prior user text, falls through. |
 | Streaming and non-streaming paths | Both share `translateToOpenAI`; both get the feature. |
 
 ## Testing
@@ -123,15 +185,21 @@ doesn't exist — to be checked at implementation time):
 
 | Test | Assertion |
 |---|---|
-| `"please think about this"` | budget = 4000 |
+| `"think about this"` (start of message) | budget = 4000 |
+| `"I think we should refactor"` (mid-sentence bare `think`) | budget = undefined (start-of-line required) |
 | `"think hard about X"` | budget = 10000 |
 | `"ultrathink: refactor"` | budget = 31999 |
 | `"think hard, then ultrathink"` | budget = 31999 (highest wins) |
 | `"do X"` (no keyword) | budget = whatever payload.thinking sent (or undefined) |
 | `"thinking about it"` (substring) | budget = undefined (word boundary) |
-| `payload.thinking.budget_tokens=5000` + prompt has `ultrathink` | budget = 31999 (override) |
+| ``"```\nthink\n```"`` (inside fenced code) | budget = undefined (code stripped) |
+| `payload.thinking.budget_tokens=10000` + prompt has bare `think` | budget = 10000 (floor: keyword does not lower) |
+| `payload.thinking.budget_tokens=4000` + prompt has `ultrathink` | budget = 31999 (floor: keyword raises) |
+| `payload.thinking.budget_tokens=5000` + prompt has `ultrathink` | budget = 31999 (override upward) |
 | `max_tokens=500` + `ultrathink` | budget = 499 (clamp) |
-| Last user msg = image only; prior user msg has `think` | budget = undefined (only last scanned) |
+| Last user msg = image only; prior user msg has `think` (start of line) | budget = 4000 (walks back past image-only turn) |
+| Last user msg = tool_result blocks only; prior user msg has `ultrathink` | budget = 31999 (sticky across tool loop) |
+| Two assistant tool_use turns interleaved with tool_result user turns; original user prompt has `ultrathink` | budget = 31999 (still sticky after multi-step tool loop) |
 
 Plus a live smoke test against the running server using `curl`, matching the
 pattern used to verify the original `thinking_budget` patch.
@@ -147,13 +215,16 @@ Add a "Per-prompt budget override" sub-subsection under "Extended Thinking
 >
 > | Trigger | Budget |
 > |---|---|
-> | `think` | 4000 |
+> | `think` (at start of a line) | 4000 |
 > | `think hard` / `megathink` | 10000 |
 > | `think harder` / `ultrathink` | 31999 |
 >
-> The translator scans the last user message; the highest-budget match wins;
-> the keyword is left in the prompt verbatim. Triggers override
-> `MAX_THINKING_TOKENS` for that request only — the next user prompt
+> The translator scans the most recent user message that contains text
+> (skipping tool-result-only turns mid-loop), strips fenced code blocks,
+> then matches. The highest-budget trigger wins. Triggers act as a **floor**
+> — they raise `MAX_THINKING_TOKENS` for that request but cannot lower it,
+> so a casual `think` in your prompt won't downgrade an explicit higher
+> budget. The keyword is left in the prompt verbatim. The next user prompt
 > re-evaluates.
 
 Add one sentence to `CLAUDE.md` in the fork-specific section noting keyword
@@ -162,8 +233,10 @@ override.
 ## Files touched
 
 - `src/routes/messages/non-stream-translation.ts` — add `THINKING_KEYWORDS`,
-  `detectKeywordBudget`, and 3-line wiring in `translateToOpenAI`
-- `tests/non-stream-translation.test.ts` (or new file) — 9 new test cases
+  `extractUserText`, `detectKeywordBudget`, and ~5-line wiring in
+  `translateToOpenAI` (floor semantics)
+- `tests/non-stream-translation.test.ts` (or new file) — ~14 new test cases
+  including agentic-loop sticky-behavior coverage
 - `README.md` — sub-subsection on per-prompt override
 - `CLAUDE.md` — one sentence in fork-specific section
 

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -92,16 +92,35 @@ const THINKING_KEYWORDS: ReadonlyArray<{ pattern: RegExp; budget: number }> = [
 
 const FENCED_CODE_BLOCK = /```[\s\S]*?```/g
 
-function extractUserText(message: AnthropicUserMessage): string {
-  if (typeof message.content === "string") return message.content
-  return message.content
-    .filter((b): b is AnthropicTextBlock => b.type === "text")
-    .map((b) => b.text)
-    .join("\n")
+// Structural shape both AnthropicMessage and the chat-completions Message
+// satisfy. We only inspect user-role text content, so any message whose
+// content is a string or an array of typed blocks works.
+export interface KeywordSourceMessage {
+  role: string
+  content?: unknown
+}
+
+function extractUserText(content: unknown): string {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  const parts: Array<string> = []
+  for (const block of content) {
+    if (
+      typeof block === "object"
+      && block !== null
+      && "type" in block
+      && (block as { type: unknown }).type === "text"
+      && "text" in block
+      && typeof (block as { text: unknown }).text === "string"
+    ) {
+      parts.push((block as { text: string }).text)
+    }
+  }
+  return parts.join("\n")
 }
 
 export function detectKeywordBudget(
-  messages: Array<AnthropicMessage>,
+  messages: ReadonlyArray<KeywordSourceMessage>,
 ): number | undefined {
   // Walk back to the most recent user-authored TEXT message, skipping
   // user-role turns that contain only tool_result / image blocks (they
@@ -110,7 +129,7 @@ export function detectKeywordBudget(
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i]
     if (m.role !== "user") continue
-    const candidate = extractUserText(m)
+    const candidate = extractUserText(m.content)
     if (candidate.trim().length > 0) {
       text = candidate
       break

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -29,6 +29,12 @@ import { mapOpenAIStopReasonToAnthropic } from "./utils"
 export function translateToOpenAI(
   payload: AnthropicMessagesPayload,
 ): ChatCompletionsPayload {
+  const thinkingBudget =
+    payload.thinking?.type === "enabled" ?
+      resolveThinkingBudget(payload.thinking.budget_tokens, payload.max_tokens)
+    : undefined
+  const thinkingOn = thinkingBudget !== undefined
+
   return {
     model: translateModelName(payload.model),
     messages: translateAnthropicMessagesToOpenAI(
@@ -38,12 +44,28 @@ export function translateToOpenAI(
     max_tokens: payload.max_tokens,
     stop: payload.stop_sequences,
     stream: payload.stream,
-    temperature: payload.temperature,
-    top_p: payload.top_p,
+    // Anthropic forbids temperature/top_p when extended thinking is on; Copilot's
+    // broker mirrors that constraint, so drop them when forwarding a budget.
+    temperature: thinkingOn ? undefined : payload.temperature,
+    top_p: thinkingOn ? undefined : payload.top_p,
     user: payload.metadata?.user_id,
     tools: translateAnthropicToolsToOpenAI(payload.tools),
     tool_choice: translateAnthropicToolChoiceToOpenAI(payload.tool_choice),
+    ...(thinkingOn && { thinking_budget: thinkingBudget }),
   }
+}
+
+// vscode-copilot-chat clamps the budget to [min, maxBudget, max_tokens-1].
+// We don't know the per-model min/max here, so we only enforce the max_tokens-1
+// invariant Anthropic requires (budget < max_tokens). Copilot's broker handles
+// per-model clamping on its side.
+function resolveThinkingBudget(
+  requested: number | undefined,
+  maxTokens: number,
+): number | undefined {
+  if (requested === undefined || requested <= 0) return undefined
+  const ceiling = Math.max(1, maxTokens - 1)
+  return Math.min(requested, ceiling)
 }
 
 function translateModelName(model: string): string {

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -29,10 +29,23 @@ import { mapOpenAIStopReasonToAnthropic } from "./utils"
 export function translateToOpenAI(
   payload: AnthropicMessagesPayload,
 ): ChatCompletionsPayload {
-  const thinkingBudget =
+  const keywordBudget = detectKeywordBudget(payload.messages)
+  const payloadBudget =
     payload.thinking?.type === "enabled" ?
-      resolveThinkingBudget(payload.thinking.budget_tokens, payload.max_tokens)
+      payload.thinking.budget_tokens
     : undefined
+
+  // Floor semantics: keyword can raise an explicit MAX_THINKING_TOKENS
+  // budget but must never silently lower it.
+  const requestedBudget =
+    keywordBudget !== undefined && payloadBudget !== undefined ?
+      Math.max(keywordBudget, payloadBudget)
+    : (keywordBudget ?? payloadBudget)
+
+  const thinkingBudget = resolveThinkingBudget(
+    requestedBudget,
+    payload.max_tokens,
+  )
   const thinkingOn = thinkingBudget !== undefined
 
   return {

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -68,6 +68,52 @@ function resolveThinkingBudget(
   return Math.min(requested, ceiling)
 }
 
+// Per-prompt thinking-budget keyword triggers. Compound forms (megathink,
+// ultrathink, think hard/harder) match anywhere; bare `think` requires
+// start-of-line to avoid firing on incidental "I think we should..." prose.
+const THINKING_KEYWORDS: ReadonlyArray<{ pattern: RegExp; budget: number }> = [
+  { pattern: /\b(?:think harder|ultrathink)\b/i, budget: 31999 },
+  { pattern: /\b(?:think hard|megathink)\b/i, budget: 10000 },
+  { pattern: /(?:^|\n)\s*think\b/i, budget: 4000 },
+]
+
+const FENCED_CODE_BLOCK = /```[\s\S]*?```/g
+
+function extractUserText(message: AnthropicUserMessage): string {
+  if (typeof message.content === "string") return message.content
+  return message.content
+    .filter((b): b is AnthropicTextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n")
+}
+
+export function detectKeywordBudget(
+  messages: Array<AnthropicMessage>,
+): number | undefined {
+  // Walk back to the most recent user-authored TEXT message, skipping
+  // user-role turns that contain only tool_result / image blocks (they
+  // appear after every assistant tool_use in agentic loops).
+  let text: string | undefined
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role !== "user") continue
+    const candidate = extractUserText(m)
+    if (candidate.trim().length > 0) {
+      text = candidate
+      break
+    }
+  }
+  if (text === undefined) return undefined
+
+  // Strip fenced code blocks so triggers inside code samples don't fire.
+  const scrubbed = text.replaceAll(FENCED_CODE_BLOCK, "")
+
+  for (const { pattern, budget } of THINKING_KEYWORDS) {
+    if (pattern.test(scrubbed)) return budget
+  }
+  return undefined
+}
+
 function translateModelName(model: string): string {
   // Subagent requests use a specific model number which Copilot doesn't support
   if (model.startsWith("claude-sonnet-4-")) {

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -1,0 +1,178 @@
+import type { Context } from "hono"
+import type { ContentfulStatusCode } from "hono/utils/http-status"
+
+import consola from "consola"
+import { streamSSE } from "hono/streaming"
+import { randomBytes } from "node:crypto"
+
+import { awaitApproval } from "~/lib/approval"
+import { HTTPError } from "~/lib/error"
+import { checkRateLimit } from "~/lib/rate-limit"
+import { state } from "~/lib/state"
+import {
+  createChatCompletions,
+  type ChatCompletionChunk,
+  type ChatCompletionResponse,
+} from "~/services/copilot/create-chat-completions"
+
+import {
+  ResponsesValidationError,
+  translateResponsesToOpenAI,
+} from "./request-translation"
+import { type ResponsesRequest } from "./responses-types"
+import {
+  createInitialStreamState,
+  finalizeStream,
+  translateChunkToResponsesEvents,
+  translateNonStreamingResponse,
+  translateStreamErrorToResponsesEvent,
+  type ResponsesStreamContext,
+} from "./stream-translation"
+
+// eslint-disable-next-line max-lines-per-function
+export async function handleResponses(c: Context) {
+  await checkRateLimit(state)
+
+  const responsesPayload = await c.req.json<ResponsesRequest>()
+  consola.debug("Responses request payload:", JSON.stringify(responsesPayload))
+
+  let translation
+  try {
+    translation = translateResponsesToOpenAI(responsesPayload)
+  } catch (error) {
+    if (error instanceof ResponsesValidationError) {
+      return c.json(
+        {
+          error: {
+            type: errorTypeForStatus(error.status),
+            message: error.message,
+            code: error.code,
+          },
+        },
+        error.status as ContentfulStatusCode,
+      )
+    }
+    throw error
+  }
+
+  const { payload: openAIPayload, syntheticToolMap } = translation
+  consola.debug(
+    "Translated OpenAI request payload:",
+    JSON.stringify(openAIPayload),
+  )
+
+  if (state.manualApprove) {
+    await awaitApproval()
+  }
+
+  const ctx: ResponsesStreamContext = {
+    responseId: `resp_${randomBytes(12).toString("hex")}`,
+    model: responsesPayload.model,
+    createdAt: Math.floor(Date.now() / 1000),
+    syntheticToolMap,
+  }
+
+  let response
+  try {
+    response = await createChatCompletions(openAIPayload)
+  } catch (error) {
+    // Pre-stream upstream failure → HTTP error envelope.
+    if (error instanceof HTTPError) {
+      const status = error.response.status
+      const text = await error.response.text()
+      return c.json(
+        {
+          error: {
+            type: errorTypeForStatus(status),
+            message: text || error.message,
+          },
+        },
+        status as ContentfulStatusCode,
+      )
+    }
+    throw error
+  }
+
+  if (isNonStreaming(response)) {
+    consola.debug(
+      "Non-streaming response from Copilot:",
+      JSON.stringify(response).slice(-400),
+    )
+    const envelope = translateNonStreamingResponse(response, ctx)
+    return c.json(envelope)
+  }
+
+  consola.debug("Streaming response from Copilot")
+  return streamSSE(c, async (stream) => {
+    const streamState = createInitialStreamState()
+    let receivedAnyChunk = false
+
+    try {
+      for await (const rawEvent of response) {
+        if (rawEvent.data === "[DONE]") {
+          break
+        }
+        if (!rawEvent.data) continue
+
+        const chunk = JSON.parse(rawEvent.data) as ChatCompletionChunk
+        receivedAnyChunk = true
+        const events = translateChunkToResponsesEvents(chunk, streamState, ctx)
+        for (const event of events) {
+          await stream.writeSSE({
+            event: event.type,
+            data: JSON.stringify(event),
+          })
+        }
+      }
+    } catch (error) {
+      consola.error("Stream translation error:", error)
+      if (streamState.responseCreatedSent) {
+        const failed = translateStreamErrorToResponsesEvent(error, ctx)
+        await stream.writeSSE({
+          event: failed.type,
+          data: JSON.stringify(failed),
+        })
+      }
+      return
+    }
+
+    // Detect transport cut: stream ended without finish_reason and without
+    // a [DONE] terminator that would have triggered finalization.
+    if (!streamState.finalized) {
+      if (!receivedAnyChunk) {
+        // Should not happen — pre-stream errors are caught earlier.
+        const failed = translateStreamErrorToResponsesEvent(
+          new Error("Upstream stream produced no content."),
+          ctx,
+        )
+        await stream.writeSSE({
+          event: failed.type,
+          data: JSON.stringify(failed),
+        })
+        return
+      }
+      const events = finalizeStream(streamState, ctx, { transportCut: true })
+      for (const event of events) {
+        await stream.writeSSE({
+          event: event.type,
+          data: JSON.stringify(event),
+        })
+      }
+    }
+  })
+}
+
+const isNonStreaming = (
+  response: Awaited<ReturnType<typeof createChatCompletions>>,
+): response is ChatCompletionResponse => Object.hasOwn(response, "choices")
+
+function errorTypeForStatus(status: number): string {
+  if (status === 400) return "invalid_request_error"
+  if (status === 401) return "authentication_error"
+  if (status === 403) return "permission_error"
+  if (status === 404) return "not_found_error"
+  if (status === 408 || status === 504) return "timeout_error"
+  if (status === 429) return "rate_limit_error"
+  if (status >= 500) return "api_error"
+  return "api_error"
+}

--- a/src/routes/responses/request-translation.ts
+++ b/src/routes/responses/request-translation.ts
@@ -1,0 +1,587 @@
+import {
+  type ChatCompletionsPayload,
+  type ContentPart,
+  type Message,
+  type Tool,
+  type ToolCall,
+} from "~/services/copilot/create-chat-completions"
+
+import { detectKeywordBudget } from "../messages/non-stream-translation"
+import {
+  type ResponsesAllowedToolEntry,
+  type ResponsesContentPart,
+  type ResponsesCustomToolCallItem,
+  type ResponsesFunctionCallItem,
+  type ResponsesInputItem,
+  type ResponsesLocalShellCallItem,
+  type ResponsesMessageItem,
+  type ResponsesRequest,
+  type ResponsesTool,
+  type ResponsesToolChoice,
+} from "./responses-types"
+
+// ----- Errors --------------------------------------------------------------
+
+export type ResponsesValidationCode =
+  | "unsupported_responses_field"
+  | "reserved_tool_name"
+  | "unknown_tool_in_choice"
+  | "empty_allowed_tools"
+  | "unsupported_tool_in_choice"
+
+export class ResponsesValidationError extends Error {
+  code: ResponsesValidationCode
+  status: number
+
+  constructor(
+    code: ResponsesValidationCode,
+    message: string,
+    status: number = 400,
+  ) {
+    super(message)
+    this.code = code
+    this.status = status
+  }
+}
+
+// ----- Synthetic tool registry --------------------------------------------
+
+export const RESERVED_TOOL_PREFIX = "__cp_"
+export const LOCAL_SHELL_TOOL = "__cp_local_shell"
+
+export type SyntheticFamily = "local_shell" | "custom"
+
+export interface SyntheticToolEntry {
+  family: SyntheticFamily
+  /** Original Codex `custom` tool name; undefined for local_shell. */
+  originalName?: string
+}
+
+export type SyntheticToolMap = Map<string, SyntheticToolEntry>
+
+const LOCAL_SHELL_PARAMETERS: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    type: { type: "string", enum: ["exec"] },
+    command: { type: "array", items: { type: "string" } },
+    workdir: { type: "string" },
+    env: { type: "object", additionalProperties: { type: "string" } },
+    timeout_ms: { type: "integer" },
+  },
+  required: ["command"],
+  additionalProperties: false,
+}
+
+const CUSTOM_TOOL_PARAMETERS: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    input: { type: "string" },
+  },
+  required: ["input"],
+  additionalProperties: false,
+}
+
+// ----- Reasoning effort anchors -------------------------------------------
+
+const REASONING_ANCHORS: Record<
+  NonNullable<ResponsesRequest["reasoning"]>["effort"] & string,
+  number | undefined
+> = {
+  minimal: undefined,
+  low: 4000,
+  medium: 10000,
+  high: 31999,
+}
+
+function resolveThinkingBudget(
+  requested: number | undefined,
+  maxTokens: number | undefined,
+): number | undefined {
+  if (requested === undefined || requested <= 0) return undefined
+  if (maxTokens === undefined) return requested
+  const ceiling = Math.max(1, maxTokens - 1)
+  return Math.min(requested, ceiling)
+}
+
+// ----- Public entry point --------------------------------------------------
+
+export interface RequestTranslationResult {
+  payload: ChatCompletionsPayload
+  syntheticToolMap: SyntheticToolMap
+}
+
+export function translateResponsesToOpenAI(
+  req: ResponsesRequest,
+): RequestTranslationResult {
+  // 1. Reject unsupported continuation/storage features.
+  if (req.previous_response_id !== undefined) {
+    throw new ResponsesValidationError(
+      "unsupported_responses_field",
+      "previous_response_id is not supported by this proxy.",
+    )
+  }
+  if (req.store === true) {
+    throw new ResponsesValidationError(
+      "unsupported_responses_field",
+      "store: true is not supported by this proxy.",
+    )
+  }
+  if (req.background === true) {
+    throw new ResponsesValidationError(
+      "unsupported_responses_field",
+      "background: true is not supported by this proxy.",
+    )
+  }
+
+  // 2. Validate reserved tool names in declared tools and historical input.
+  validateReservedToolNames(req.tools, req.input)
+
+  // 3. Lower tools.
+  const { lowered: loweredTools, syntheticToolMap } = lowerTools(req.tools)
+
+  // 4. Translate input + instructions into messages[].
+  const messages = buildMessages(req.input, req.instructions, syntheticToolMap)
+
+  // 5. Reasoning effort + keyword floor → thinking_budget (Claude only).
+  const isClaude = req.model.startsWith("claude-")
+  const effortBudget =
+    isClaude && req.reasoning?.effort !== undefined ?
+      REASONING_ANCHORS[req.reasoning.effort]
+    : undefined
+
+  let thinkingBudget: number | undefined
+  if (isClaude) {
+    const keywordBudget = detectKeywordBudget(messages)
+    const requested =
+      keywordBudget !== undefined && effortBudget !== undefined ?
+        Math.max(keywordBudget, effortBudget)
+      : (keywordBudget ?? effortBudget)
+    thinkingBudget = resolveThinkingBudget(requested, req.max_output_tokens)
+  }
+  const thinkingOn = thinkingBudget !== undefined
+
+  // 6. Translate tool_choice (uses syntheticToolMap to resolve allowed_tools).
+  const toolChoice = translateToolChoice(
+    req.tool_choice,
+    req.tools,
+    syntheticToolMap,
+  )
+
+  const payload: ChatCompletionsPayload = {
+    model: req.model,
+    messages,
+    max_tokens: req.max_output_tokens,
+    stream: req.stream,
+    temperature: thinkingOn ? undefined : req.temperature,
+    top_p: thinkingOn ? undefined : req.top_p,
+    user: req.metadata?.user_id,
+    tools: loweredTools,
+    tool_choice: toolChoice,
+    ...(thinkingOn && { thinking_budget: thinkingBudget }),
+  }
+
+  return { payload, syntheticToolMap }
+}
+
+// ----- Reserved name validation -------------------------------------------
+
+function validateReservedToolNames(
+  tools: Array<ResponsesTool> | undefined,
+  input: Array<ResponsesInputItem>,
+): void {
+  if (tools) {
+    for (const tool of tools) {
+      if (tool.type !== "function" && tool.type !== "custom") continue
+      const name = getName(tool)
+      if (name?.startsWith(RESERVED_TOOL_PREFIX)) {
+        throw new ResponsesValidationError(
+          "reserved_tool_name",
+          `Tool name "${name}" uses the reserved "${RESERVED_TOOL_PREFIX}" prefix.`,
+        )
+      }
+    }
+  }
+  for (const item of input) {
+    if (item.type !== "function_call") continue
+    const name = getName(item)
+    if (name?.startsWith(RESERVED_TOOL_PREFIX)) {
+      throw new ResponsesValidationError(
+        "reserved_tool_name",
+        `History contains function_call with reserved name "${name}".`,
+      )
+    }
+  }
+}
+
+function getName(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) return undefined
+  const name = (value as { name?: unknown }).name
+  return typeof name === "string" ? name : undefined
+}
+
+// ----- Tool lowering -------------------------------------------------------
+
+interface LoweredToolsResult {
+  lowered: Array<Tool> | undefined
+  syntheticToolMap: SyntheticToolMap
+}
+
+function lowerTools(
+  tools: Array<ResponsesTool> | undefined,
+): LoweredToolsResult {
+  const syntheticToolMap: SyntheticToolMap = new Map()
+  if (!tools || tools.length === 0) {
+    return { lowered: undefined, syntheticToolMap }
+  }
+
+  const lowered: Array<Tool> = []
+  let customCounter = 0
+
+  for (const tool of tools) {
+    switch (tool.type) {
+      case "function": {
+        const fn = tool as Extract<ResponsesTool, { type: "function" }>
+        const entry: Tool = {
+          type: "function",
+          function: {
+            name: fn.name,
+            description: fn.description,
+            parameters: fn.parameters ?? {
+              type: "object",
+              properties: {},
+            },
+          },
+        }
+        lowered.push(entry)
+        break
+      }
+      case "local_shell": {
+        if (!syntheticToolMap.has(LOCAL_SHELL_TOOL)) {
+          syntheticToolMap.set(LOCAL_SHELL_TOOL, { family: "local_shell" })
+          lowered.push({
+            type: "function",
+            function: {
+              name: LOCAL_SHELL_TOOL,
+              description: "Execute a local shell command.",
+              parameters: LOCAL_SHELL_PARAMETERS,
+            },
+          })
+        }
+        break
+      }
+      case "custom": {
+        const ct = tool as Extract<ResponsesTool, { type: "custom" }>
+        const syntheticName = `__cp_custom_${customCounter}`
+        customCounter++
+        syntheticToolMap.set(syntheticName, {
+          family: "custom",
+          originalName: ct.name,
+        })
+        lowered.push({
+          type: "function",
+          function: {
+            name: syntheticName,
+            description: ct.description ?? `Custom tool ${ct.name}`,
+            parameters: CUSTOM_TOOL_PARAMETERS,
+          },
+        })
+        break
+      }
+      case "web_search":
+      case "web_search_preview": {
+        // Unsupported — drop with a verbose log; let the model recover.
+        // (verbose log handled at handler entry)
+        break
+      }
+      default: {
+        // Unknown tool type — drop.
+        break
+      }
+    }
+  }
+
+  return {
+    lowered: lowered.length > 0 ? lowered : undefined,
+    syntheticToolMap,
+  }
+}
+
+// ----- tool_choice translation --------------------------------------------
+
+function translateToolChoice(
+  choice: ResponsesToolChoice | undefined,
+  tools: Array<ResponsesTool> | undefined,
+  syntheticToolMap: SyntheticToolMap,
+): ChatCompletionsPayload["tool_choice"] {
+  if (choice === undefined) return undefined
+
+  if (typeof choice === "string") {
+    return choice
+  }
+
+  if (choice.type === "function" || choice.type === "custom") {
+    const target =
+      choice.type === "function" ?
+        choice.name
+      : findSyntheticForCustomName(syntheticToolMap, choice.name)
+    if (!target) {
+      throw new ResponsesValidationError(
+        "unknown_tool_in_choice",
+        `tool_choice references unknown tool "${choice.name}".`,
+      )
+    }
+    return { type: "function", function: { name: target } }
+  }
+
+  // choice.type === "allowed_tools"
+  const resolved = resolveAllowedTools(choice.tools, tools, syntheticToolMap)
+  if (resolved.length === 0) {
+    throw new ResponsesValidationError(
+      "empty_allowed_tools",
+      "tool_choice.allowed_tools resolved to an empty set.",
+    )
+  }
+  // chat/completions has no native allowed_tools mode. If exactly one tool
+  // resolves we can pin it; otherwise we forward the requested mode and
+  // trust the model — the unmatched tools are still in `tools[]`, which is
+  // a known limitation. mode:"required" maps to "required"; "auto" → "auto".
+  if (resolved.length === 1) {
+    return { type: "function", function: { name: resolved[0] } }
+  }
+  return choice.mode === "required" ? "required" : "auto"
+}
+
+function findSyntheticForCustomName(
+  map: SyntheticToolMap,
+  originalName: string,
+): string | undefined {
+  for (const [synthetic, entry] of map.entries()) {
+    if (entry.family === "custom" && entry.originalName === originalName) {
+      return synthetic
+    }
+  }
+  return undefined
+}
+
+// eslint-disable-next-line complexity
+function resolveAllowedTools(
+  entries: Array<ResponsesAllowedToolEntry>,
+  tools: Array<ResponsesTool> | undefined,
+  syntheticToolMap: SyntheticToolMap,
+): Array<string> {
+  const declaredFunctionNames = new Set<string>()
+  if (tools) {
+    for (const t of tools) {
+      if (t.type !== "function") continue
+      const name = getName(t)
+      if (name) declaredFunctionNames.add(name)
+    }
+  }
+
+  const out: Array<string> = []
+  for (const entry of entries) {
+    if (entry === "local_shell") {
+      if (!syntheticToolMap.has(LOCAL_SHELL_TOOL)) {
+        throw new ResponsesValidationError(
+          "unknown_tool_in_choice",
+          `tool_choice.allowed_tools references "local_shell" but no local_shell tool was declared.`,
+        )
+      }
+      out.push(LOCAL_SHELL_TOOL)
+      continue
+    }
+    if (typeof entry === "object") {
+      const entryType = (entry as { type: string }).type
+      const entryName = (entry as { name?: string }).name
+      if (entryType === "function") {
+        if (!entryName || !declaredFunctionNames.has(entryName)) {
+          throw new ResponsesValidationError(
+            "unknown_tool_in_choice",
+            `tool_choice.allowed_tools references unknown function "${entryName}".`,
+          )
+        }
+        out.push(entryName)
+        continue
+      }
+      if (entryType === "custom") {
+        const synth =
+          entryName ?
+            findSyntheticForCustomName(syntheticToolMap, entryName)
+          : undefined
+        if (!synth) {
+          throw new ResponsesValidationError(
+            "unknown_tool_in_choice",
+            `tool_choice.allowed_tools references unknown custom tool "${entryName}".`,
+          )
+        }
+        out.push(synth)
+        continue
+      }
+      if (entryType === "local_shell") {
+        if (!syntheticToolMap.has(LOCAL_SHELL_TOOL)) {
+          throw new ResponsesValidationError(
+            "unknown_tool_in_choice",
+            `tool_choice.allowed_tools references "local_shell" but no local_shell tool was declared.`,
+          )
+        }
+        out.push(LOCAL_SHELL_TOOL)
+        continue
+      }
+      if (entryType === "web_search" || entryType === "web_search_preview") {
+        throw new ResponsesValidationError(
+          "unsupported_tool_in_choice",
+          `tool_choice.allowed_tools references unsupported tool "web_search".`,
+        )
+      }
+    }
+    throw new ResponsesValidationError(
+      "unknown_tool_in_choice",
+      `tool_choice.allowed_tools entry could not be resolved.`,
+    )
+  }
+  return out
+}
+
+// ----- input[] → messages[] -----------------------------------------------
+
+function buildMessages(
+  input: Array<ResponsesInputItem>,
+  instructions: string | undefined,
+  syntheticToolMap: SyntheticToolMap,
+): Array<Message> {
+  const messages: Array<Message> = []
+  if (instructions) {
+    messages.push({ role: "system", content: instructions })
+  }
+
+  // We coalesce consecutive function-call items into one assistant message
+  // with tool_calls[]; `*_output` items become standalone tool messages.
+  let pendingToolCalls: Array<ToolCall> = []
+
+  const flushPendingToolCalls = () => {
+    if (pendingToolCalls.length === 0) return
+    messages.push({
+      role: "assistant",
+      content: null,
+      tool_calls: pendingToolCalls,
+    })
+    pendingToolCalls = []
+  }
+
+  for (const item of input) {
+    switch (item.type) {
+      case "message": {
+        flushPendingToolCalls()
+        const msg = item as ResponsesMessageItem
+        const content = mapResponsesContent(msg.content)
+        const role = msg.role === "developer" ? "system" : msg.role
+        messages.push({ role, content })
+        break
+      }
+      case "function_call": {
+        const fc = item as ResponsesFunctionCallItem
+        pendingToolCalls.push({
+          id: fc.call_id,
+          type: "function",
+          function: { name: fc.name, arguments: fc.arguments },
+        })
+        break
+      }
+      case "local_shell_call": {
+        // Need a synthetic mapping for raising responses back. If the user
+        // didn't declare a local_shell tool but is replaying history with
+        // one, register it implicitly so future raise can succeed.
+        if (!syntheticToolMap.has(LOCAL_SHELL_TOOL)) {
+          syntheticToolMap.set(LOCAL_SHELL_TOOL, { family: "local_shell" })
+        }
+        const lsc = item as ResponsesLocalShellCallItem
+        pendingToolCalls.push({
+          id: lsc.call_id,
+          type: "function",
+          function: {
+            name: LOCAL_SHELL_TOOL,
+            arguments: JSON.stringify(lsc.action),
+          },
+        })
+        break
+      }
+      case "custom_tool_call": {
+        const ctc = item as ResponsesCustomToolCallItem
+        const synth = findSyntheticForCustomName(syntheticToolMap, ctc.name)
+        if (!synth) {
+          // Fallback: treat as a plain function call so the upstream can see
+          // it; downstream raise won't fire (no synthetic id) so it stays a
+          // function_call in any echo. This preserves at-least history.
+          pendingToolCalls.push({
+            id: ctc.call_id,
+            type: "function",
+            function: {
+              name: ctc.name,
+              arguments: JSON.stringify({ input: ctc.input }),
+            },
+          })
+          break
+        }
+        pendingToolCalls.push({
+          id: ctc.call_id,
+          type: "function",
+          function: {
+            name: synth,
+            arguments: JSON.stringify({ input: ctc.input }),
+          },
+        })
+        break
+      }
+      case "function_call_output":
+      case "local_shell_call_output":
+      case "custom_tool_call_output": {
+        flushPendingToolCalls()
+        const out = item as { call_id: string; output: string }
+        messages.push({
+          role: "tool",
+          tool_call_id: out.call_id,
+          content: out.output,
+        })
+        break
+      }
+      case "reasoning": {
+        // Dropped per spec.
+        break
+      }
+      default: {
+        // Unknown — drop with verbose log; logging is at handler entry.
+        break
+      }
+    }
+  }
+  flushPendingToolCalls()
+
+  return messages
+}
+
+function mapResponsesContent(
+  content: Array<ResponsesContentPart>,
+): string | Array<ContentPart> {
+  const hasImage = content.some((p) => p.type === "input_image")
+  if (!hasImage) {
+    return content
+      .filter(
+        (p): p is { type: "input_text" | "output_text"; text: string } =>
+          p.type === "input_text" || p.type === "output_text",
+      )
+      .map((p) => p.text)
+      .join("\n\n")
+  }
+  const parts: Array<ContentPart> = []
+  for (const p of content) {
+    if (p.type === "input_text" || p.type === "output_text") {
+      parts.push({ type: "text", text: p.text })
+    } else {
+      parts.push({
+        type: "image_url",
+        image_url: { url: p.image_url, detail: p.detail },
+      })
+    }
+  }
+  return parts
+}

--- a/src/routes/responses/responses-types.ts
+++ b/src/routes/responses/responses-types.ts
@@ -1,0 +1,316 @@
+// OpenAI Responses API — incoming payload types from Codex CLI.
+
+export interface ResponsesInputTextPart {
+  type: "input_text"
+  text: string
+}
+
+export interface ResponsesOutputTextPart {
+  type: "output_text"
+  text: string
+}
+
+export interface ResponsesInputImagePart {
+  type: "input_image"
+  image_url: string
+  detail?: "low" | "high" | "auto"
+}
+
+export type ResponsesContentPart =
+  | ResponsesInputTextPart
+  | ResponsesOutputTextPart
+  | ResponsesInputImagePart
+
+export interface ResponsesMessageItem {
+  type: "message"
+  role: "user" | "assistant" | "system" | "developer"
+  content: Array<ResponsesContentPart>
+}
+
+export interface ResponsesFunctionCallItem {
+  type: "function_call"
+  call_id: string
+  name: string
+  arguments: string
+  id?: string
+}
+
+export interface ResponsesFunctionCallOutputItem {
+  type: "function_call_output"
+  call_id: string
+  output: string
+}
+
+export interface ResponsesLocalShellAction {
+  type?: "exec"
+  command: Array<string>
+  workdir?: string
+  env?: Record<string, string>
+  timeout_ms?: number
+}
+
+export interface ResponsesLocalShellCallItem {
+  type: "local_shell_call"
+  call_id: string
+  action: ResponsesLocalShellAction
+  id?: string
+  status?: string
+}
+
+export interface ResponsesLocalShellCallOutputItem {
+  type: "local_shell_call_output"
+  call_id: string
+  output: string
+}
+
+export interface ResponsesCustomToolCallItem {
+  type: "custom_tool_call"
+  call_id: string
+  name: string
+  input: string
+  id?: string
+}
+
+export interface ResponsesCustomToolCallOutputItem {
+  type: "custom_tool_call_output"
+  call_id: string
+  output: string
+}
+
+export interface ResponsesReasoningItem {
+  type: "reasoning"
+  // shape intentionally loose — we drop these
+  [key: string]: unknown
+}
+
+export type ResponsesInputItem =
+  | ResponsesMessageItem
+  | ResponsesFunctionCallItem
+  | ResponsesFunctionCallOutputItem
+  | ResponsesLocalShellCallItem
+  | ResponsesLocalShellCallOutputItem
+  | ResponsesCustomToolCallItem
+  | ResponsesCustomToolCallOutputItem
+  | ResponsesReasoningItem
+  | { type: string; [key: string]: unknown }
+
+export interface ResponsesFunctionTool {
+  type: "function"
+  name: string
+  description?: string
+  parameters?: Record<string, unknown>
+  strict?: boolean
+}
+
+export interface ResponsesLocalShellTool {
+  type: "local_shell"
+}
+
+export interface ResponsesCustomTool {
+  type: "custom"
+  name: string
+  description?: string
+}
+
+export interface ResponsesWebSearchTool {
+  type: "web_search" | "web_search_preview"
+}
+
+export type ResponsesTool =
+  | ResponsesFunctionTool
+  | ResponsesLocalShellTool
+  | ResponsesCustomTool
+  | ResponsesWebSearchTool
+  | { type: string; [key: string]: unknown }
+
+export type ResponsesAllowedToolEntry =
+  | "local_shell"
+  | { type: "function" | "custom" | "local_shell"; name?: string }
+
+export type ResponsesToolChoice =
+  | "auto"
+  | "none"
+  | "required"
+  | { type: "function"; name: string }
+  | { type: "custom"; name: string }
+  | {
+      type: "allowed_tools"
+      tools: Array<ResponsesAllowedToolEntry>
+      mode?: "auto" | "required"
+    }
+
+export interface ResponsesReasoning {
+  effort?: "minimal" | "low" | "medium" | "high"
+  summary?: string
+}
+
+export interface ResponsesRequest {
+  model: string
+  instructions?: string
+  input: Array<ResponsesInputItem>
+  tools?: Array<ResponsesTool>
+  tool_choice?: ResponsesToolChoice
+  parallel_tool_calls?: boolean
+  reasoning?: ResponsesReasoning
+  max_output_tokens?: number
+  temperature?: number
+  top_p?: number
+  metadata?: Record<string, string> & { user_id?: string }
+  stream?: boolean
+
+  // Continuation/storage features we don't support — rejected explicitly.
+  previous_response_id?: string
+  store?: boolean
+  background?: boolean
+
+  // Pass-through fields that may appear from Codex but we don't translate.
+  [key: string]: unknown
+}
+
+// Outgoing Responses SSE events (the minimum set Codex's process_sse parses).
+
+export interface ResponsesOutputMessageItem {
+  type: "message"
+  id: string
+  role: "assistant"
+  status: "in_progress" | "completed" | "incomplete"
+  content: Array<{ type: "output_text"; text: string; annotations: [] }>
+}
+
+export interface ResponsesOutputFunctionCall {
+  type: "function_call"
+  id: string
+  call_id: string
+  name: string
+  arguments: string
+  status?: "in_progress" | "completed" | "incomplete"
+}
+
+export interface ResponsesOutputLocalShellCall {
+  type: "local_shell_call"
+  id: string
+  call_id: string
+  action: ResponsesLocalShellAction
+  status?: "in_progress" | "completed" | "incomplete"
+}
+
+export interface ResponsesOutputCustomToolCall {
+  type: "custom_tool_call"
+  id: string
+  call_id: string
+  name: string
+  input: string
+  status?: "in_progress" | "completed" | "incomplete"
+}
+
+export type ResponsesOutputItem =
+  | ResponsesOutputMessageItem
+  | ResponsesOutputFunctionCall
+  | ResponsesOutputLocalShellCall
+  | ResponsesOutputCustomToolCall
+
+export interface ResponsesUsage {
+  input_tokens: number
+  output_tokens: number
+  total_tokens: number
+  input_tokens_details?: { cached_tokens?: number }
+}
+
+export type ResponsesIncompleteReason =
+  | "max_output_tokens"
+  | "content_filter"
+  | "unknown"
+
+export interface ResponsesIncompleteDetails {
+  reason: ResponsesIncompleteReason
+  upstream_reason?: string
+}
+
+export interface ResponsesEnvelope {
+  id: string
+  object: "response"
+  created_at: number
+  status: "in_progress" | "completed" | "incomplete" | "failed"
+  model: string
+  output: Array<ResponsesOutputItem>
+  usage?: ResponsesUsage
+  incomplete_details?: ResponsesIncompleteDetails
+  error?: { code: string; message: string } | null
+  metadata?: Record<string, string>
+}
+
+// SSE event variants we emit.
+
+export interface ResponseCreatedEvent {
+  type: "response.created"
+  response: ResponsesEnvelope
+}
+
+export interface ResponseInProgressEvent {
+  type: "response.in_progress"
+  response: ResponsesEnvelope
+}
+
+export interface ResponseOutputItemAddedEvent {
+  type: "response.output_item.added"
+  output_index: number
+  item: ResponsesOutputItem
+}
+
+export interface ResponseOutputItemDoneEvent {
+  type: "response.output_item.done"
+  output_index: number
+  item: ResponsesOutputItem
+}
+
+export interface ResponseOutputTextDeltaEvent {
+  type: "response.output_text.delta"
+  item_id: string
+  output_index: number
+  content_index: number
+  delta: string
+}
+
+export interface ResponseOutputTextDoneEvent {
+  type: "response.output_text.done"
+  item_id: string
+  output_index: number
+  content_index: number
+  text: string
+}
+
+export interface ResponseFunctionCallArgsDeltaEvent {
+  type: "response.function_call_arguments.delta"
+  item_id: string
+  output_index: number
+  delta: string
+}
+
+export interface ResponseFunctionCallArgsDoneEvent {
+  type: "response.function_call_arguments.done"
+  item_id: string
+  output_index: number
+  arguments: string
+}
+
+export interface ResponseCompletedEvent {
+  type: "response.completed"
+  response: ResponsesEnvelope
+}
+
+export interface ResponseFailedEvent {
+  type: "response.failed"
+  response: ResponsesEnvelope
+}
+
+export type ResponsesStreamEvent =
+  | ResponseCreatedEvent
+  | ResponseInProgressEvent
+  | ResponseOutputItemAddedEvent
+  | ResponseOutputItemDoneEvent
+  | ResponseOutputTextDeltaEvent
+  | ResponseOutputTextDoneEvent
+  | ResponseFunctionCallArgsDeltaEvent
+  | ResponseFunctionCallArgsDoneEvent
+  | ResponseCompletedEvent
+  | ResponseFailedEvent

--- a/src/routes/responses/route.ts
+++ b/src/routes/responses/route.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono"
+
+import { forwardError } from "~/lib/error"
+
+import { handleResponses } from "./handler"
+
+export const responseRoutes = new Hono()
+
+responseRoutes.post("/", async (c) => {
+  try {
+    return await handleResponses(c)
+  } catch (error) {
+    return await forwardError(c, error)
+  }
+})

--- a/src/routes/responses/stream-translation.ts
+++ b/src/routes/responses/stream-translation.ts
@@ -1,0 +1,756 @@
+import { randomBytes } from "node:crypto"
+
+import {
+  type ChatCompletionChunk,
+  type ChatCompletionResponse,
+} from "~/services/copilot/create-chat-completions"
+
+import {
+  type SyntheticFamily,
+  type SyntheticToolMap,
+} from "./request-translation"
+import {
+  type ResponsesEnvelope,
+  type ResponsesIncompleteDetails,
+  type ResponsesIncompleteReason,
+  type ResponsesLocalShellAction,
+  type ResponsesOutputCustomToolCall,
+  type ResponsesOutputFunctionCall,
+  type ResponsesOutputItem,
+  type ResponsesOutputLocalShellCall,
+  type ResponsesOutputMessageItem,
+  type ResponsesStreamEvent,
+  type ResponsesUsage,
+} from "./responses-types"
+
+// ----- State + context -----------------------------------------------------
+
+interface ToolCallAccumulator {
+  outputIndex: number
+  itemId: string
+  callId: string
+  name: string
+  argumentsBuffer: string
+  emittedAdded: boolean
+  done: boolean
+}
+
+interface MessageAccumulator {
+  outputIndex: number
+  itemId: string
+  textBuffer: string
+  emittedAdded: boolean
+  done: boolean
+}
+
+export interface ResponsesStreamState {
+  responseCreatedSent: boolean
+  nextOutputIndex: number
+  message?: MessageAccumulator
+  /** Keyed by upstream tool_call index. */
+  toolCalls: Map<number, ToolCallAccumulator>
+  /** Set once finish_reason or [DONE] has been processed. */
+  finalized: boolean
+  /** Captured usage from the terminal chunk, if any. */
+  usage?: ResponsesUsage
+  /** Captured finish_reason. */
+  finishReason: ChatCompletionChunk["choices"][number]["finish_reason"] | null
+}
+
+export interface ResponsesStreamContext {
+  responseId: string
+  model: string
+  createdAt: number
+  syntheticToolMap: SyntheticToolMap
+}
+
+export function createInitialStreamState(): ResponsesStreamState {
+  return {
+    responseCreatedSent: false,
+    nextOutputIndex: 0,
+    toolCalls: new Map(),
+    finalized: false,
+    finishReason: null,
+  }
+}
+
+// ----- ID helpers ----------------------------------------------------------
+
+const ID_PREFIXES = {
+  message: "msg",
+  function_call: "fc",
+  local_shell_call: "lsc",
+  custom_tool_call: "ctc",
+} as const
+
+function makeId(
+  prefix: keyof typeof ID_PREFIXES,
+  randomFn: () => string = defaultRandom,
+): string {
+  return `${ID_PREFIXES[prefix]}_${randomFn()}`
+}
+
+function defaultRandom(): string {
+  return randomBytes(12).toString("hex")
+}
+
+function pickFamily(
+  family: SyntheticFamily | undefined,
+): keyof typeof ID_PREFIXES {
+  if (family === "local_shell") return "local_shell_call"
+  if (family === "custom") return "custom_tool_call"
+  return "function_call"
+}
+
+// ----- Per-chunk translation ----------------------------------------------
+
+// eslint-disable-next-line max-lines-per-function, complexity
+export function translateChunkToResponsesEvents(
+  chunk: ChatCompletionChunk,
+  state: ResponsesStreamState,
+  ctx: ResponsesStreamContext,
+): Array<ResponsesStreamEvent> {
+  const events: Array<ResponsesStreamEvent> = []
+
+  if (!state.responseCreatedSent) {
+    const initial = buildEnvelope({
+      ctx,
+      status: "in_progress",
+      output: [],
+      usage: undefined,
+    })
+    events.push(
+      { type: "response.created", response: initial },
+      { type: "response.in_progress", response: initial },
+    )
+    state.responseCreatedSent = true
+  }
+
+  if (chunk.usage) {
+    state.usage = {
+      input_tokens: chunk.usage.prompt_tokens,
+      output_tokens: chunk.usage.completion_tokens,
+      total_tokens: chunk.usage.total_tokens,
+      ...(chunk.usage.prompt_tokens_details && {
+        input_tokens_details: {
+          cached_tokens: chunk.usage.prompt_tokens_details.cached_tokens,
+        },
+      }),
+    }
+  }
+
+  if (chunk.choices.length === 0) {
+    return events
+  }
+  const choice = chunk.choices[0]
+  const { delta } = choice
+
+  // ----- Text delta --------------------------------------------------------
+  if (typeof delta.content === "string" && delta.content.length > 0) {
+    if (!state.message) {
+      const itemId = makeId("message")
+      state.message = {
+        outputIndex: state.nextOutputIndex,
+        itemId,
+        textBuffer: "",
+        emittedAdded: false,
+        done: false,
+      }
+      state.nextOutputIndex++
+    }
+    if (!state.message.emittedAdded) {
+      events.push({
+        type: "response.output_item.added",
+        output_index: state.message.outputIndex,
+        item: buildMessageItem(state.message.itemId, "", "in_progress"),
+      })
+      state.message.emittedAdded = true
+    }
+    state.message.textBuffer += delta.content
+    events.push({
+      type: "response.output_text.delta",
+      item_id: state.message.itemId,
+      output_index: state.message.outputIndex,
+      content_index: 0,
+      delta: delta.content,
+    })
+  }
+
+  // ----- Tool-call deltas --------------------------------------------------
+  if (delta.tool_calls) {
+    for (const tc of delta.tool_calls) {
+      let acc = state.toolCalls.get(tc.index)
+      if (!acc && tc.id && tc.function?.name) {
+        const name = tc.function.name
+        const synthetic = ctx.syntheticToolMap.get(name)
+        const family = pickFamily(synthetic?.family)
+        acc = {
+          outputIndex: state.nextOutputIndex,
+          itemId: makeId(family),
+          callId: tc.id,
+          name,
+          argumentsBuffer: "",
+          emittedAdded: false,
+          done: false,
+        }
+        state.nextOutputIndex++
+        state.toolCalls.set(tc.index, acc)
+      }
+      if (!acc) continue
+
+      if (!acc.emittedAdded) {
+        const item = buildPlaceholderToolItem(acc, ctx)
+        if (item) {
+          events.push({
+            type: "response.output_item.added",
+            output_index: acc.outputIndex,
+            item,
+          })
+          acc.emittedAdded = true
+        }
+      }
+
+      if (tc.function?.arguments) {
+        acc.argumentsBuffer += tc.function.arguments
+        events.push({
+          type: "response.function_call_arguments.delta",
+          item_id: acc.itemId,
+          output_index: acc.outputIndex,
+          delta: tc.function.arguments,
+        })
+      }
+    }
+  }
+
+  // ----- Finalization ------------------------------------------------------
+  if (choice.finish_reason && !state.finalized) {
+    state.finalized = true
+    state.finishReason = choice.finish_reason
+    events.push(...finalizeStream(state, ctx))
+  }
+
+  return events
+}
+
+// ----- Finalization (transport-cut handling) ------------------------------
+
+interface FinalizationOptions {
+  /** True if upstream closed without a `finish_reason` (transport cut). */
+  transportCut?: boolean
+}
+
+// eslint-disable-next-line max-lines-per-function
+export function finalizeStream(
+  state: ResponsesStreamState,
+  ctx: ResponsesStreamContext,
+  options: FinalizationOptions = {},
+): Array<ResponsesStreamEvent> {
+  const events: Array<ResponsesStreamEvent> = []
+
+  // Build candidate items in output_index order.
+  const items: Array<{
+    outputIndex: number
+    item: ResponsesOutputItem
+    failed?: { code: string; message: string }
+    /** True when the failed item originated from a __cp_* synthetic family. */
+    failedSynthetic?: boolean
+  }> = []
+
+  if (state.message) {
+    const status: ResponsesOutputMessageItem["status"] =
+      options.transportCut ? "incomplete" : "completed"
+    items.push({
+      outputIndex: state.message.outputIndex,
+      item: buildMessageItem(
+        state.message.itemId,
+        state.message.textBuffer,
+        status,
+      ),
+    })
+  }
+
+  for (const acc of state.toolCalls.values()) {
+    const validation = validateToolCall(acc, ctx)
+    if (validation.failed) {
+      items.push({
+        outputIndex: acc.outputIndex,
+        item: buildFunctionCallItem(acc, "incomplete"),
+        failed: validation.failed,
+        failedSynthetic: validation.failedSynthetic,
+      })
+    } else {
+      items.push({
+        outputIndex: acc.outputIndex,
+        item: validation.item,
+      })
+    }
+  }
+
+  items.sort((a, b) => a.outputIndex - b.outputIndex)
+
+  // Transport-cut + any malformed synthetic → emit only response.failed,
+  // flush nothing. Codex acts on output_item.done; partial flush could
+  // execute a privileged call alongside a malformed sibling.
+  if (options.transportCut) {
+    const anyMalformedSynthetic = items.some(
+      (i) => i.failed && i.failedSynthetic,
+    )
+    if (anyMalformedSynthetic) {
+      events.push({
+        type: "response.failed",
+        response: buildEnvelope({
+          ctx,
+          status: "failed",
+          output: [],
+          usage: state.usage,
+          error: {
+            code: "stream_interrupted_malformed_tool_arguments",
+            message:
+              "Upstream stream ended mid-turn with malformed synthetic tool arguments.",
+          },
+        }),
+      })
+      return events
+    }
+    // Otherwise: flush valid items then complete as incomplete.
+    for (const { outputIndex, item } of items) {
+      events.push({
+        type: "response.output_item.done",
+        output_index: outputIndex,
+        item,
+      })
+    }
+    events.push({
+      type: "response.completed",
+      response: buildEnvelope({
+        ctx,
+        status: "incomplete",
+        output: items.map((i) => i.item),
+        usage: state.usage,
+        incompleteDetails: {
+          reason: "unknown",
+          upstream_reason: "stream_interrupted",
+        },
+      }),
+    })
+    return events
+  }
+
+  // Normal path: per-item failure handling differs by family.
+  let aborted: { code: string; message: string } | undefined
+  for (const entry of items) {
+    if (entry.failed) {
+      if (entry.failedSynthetic) {
+        // Don't echo the __cp_* name back; abort the whole turn.
+        aborted = entry.failed
+        break
+      }
+      // Plain function call with malformed args: pass raw string through.
+      events.push({
+        type: "response.output_item.done",
+        output_index: entry.outputIndex,
+        item: entry.item,
+      })
+      continue
+    }
+    events.push({
+      type: "response.output_item.done",
+      output_index: entry.outputIndex,
+      item: entry.item,
+    })
+  }
+
+  if (aborted) {
+    events.push({
+      type: "response.failed",
+      response: buildEnvelope({
+        ctx,
+        status: "failed",
+        output: [],
+        usage: state.usage,
+        error: aborted,
+      }),
+    })
+    return events
+  }
+
+  // Build the terminal envelope.
+  const { status, incompleteDetails } = mapFinishReason(state.finishReason)
+  events.push({
+    type: "response.completed",
+    response: buildEnvelope({
+      ctx,
+      status,
+      output: items.map((i) => i.item),
+      usage: state.usage,
+      incompleteDetails,
+    }),
+  })
+  return events
+}
+
+// ----- finish_reason mapping ----------------------------------------------
+
+function mapFinishReason(
+  finishReason: ChatCompletionChunk["choices"][number]["finish_reason"] | null,
+): {
+  status: "completed" | "incomplete"
+  incompleteDetails?: ResponsesIncompleteDetails
+} {
+  switch (finishReason) {
+    case "stop":
+    case "tool_calls":
+    case null: {
+      return { status: "completed" }
+    }
+    case "length": {
+      return {
+        status: "incomplete",
+        incompleteDetails: { reason: "max_output_tokens" },
+      }
+    }
+    case "content_filter": {
+      return {
+        status: "incomplete",
+        incompleteDetails: { reason: "content_filter" },
+      }
+    }
+    default: {
+      const reason: ResponsesIncompleteReason = "unknown"
+      return {
+        status: "incomplete",
+        incompleteDetails: { reason, upstream_reason: String(finishReason) },
+      }
+    }
+  }
+}
+
+// ----- Item builders ------------------------------------------------------
+
+function buildMessageItem(
+  itemId: string,
+  text: string,
+  status: ResponsesOutputMessageItem["status"],
+): ResponsesOutputMessageItem {
+  return {
+    type: "message",
+    id: itemId,
+    role: "assistant",
+    status,
+    content: [{ type: "output_text", text, annotations: [] }],
+  }
+}
+
+function buildFunctionCallItem(
+  acc: ToolCallAccumulator,
+  status: "in_progress" | "completed" | "incomplete",
+): ResponsesOutputFunctionCall {
+  return {
+    type: "function_call",
+    id: acc.itemId,
+    call_id: acc.callId,
+    name: acc.name,
+    arguments: acc.argumentsBuffer,
+    status,
+  }
+}
+
+function buildPlaceholderToolItem(
+  acc: ToolCallAccumulator,
+  ctx: ResponsesStreamContext,
+): ResponsesOutputItem | undefined {
+  const synthetic = ctx.syntheticToolMap.get(acc.name)
+  if (!synthetic) {
+    if (acc.name.startsWith("__cp_")) return undefined
+    return buildFunctionCallItem(acc, "in_progress")
+  }
+  if (synthetic.family === "local_shell") {
+    const placeholder: ResponsesOutputLocalShellCall = {
+      type: "local_shell_call",
+      id: acc.itemId,
+      call_id: acc.callId,
+      action: { type: "exec", command: [] },
+      status: "in_progress",
+    }
+    return placeholder
+  }
+  const placeholder: ResponsesOutputCustomToolCall = {
+    type: "custom_tool_call",
+    id: acc.itemId,
+    call_id: acc.callId,
+    name: synthetic.originalName ?? acc.name,
+    input: "",
+    status: "in_progress",
+  }
+  return placeholder
+}
+
+interface ValidationResult {
+  item: ResponsesOutputItem
+  failed?: { code: string; message: string }
+  /** True when the failed item came from a synthetic / __cp_* family. */
+  failedSynthetic?: boolean
+}
+
+function validateToolCall(
+  acc: ToolCallAccumulator,
+  ctx: ResponsesStreamContext,
+): ValidationResult {
+  const synthetic = ctx.syntheticToolMap.get(acc.name)
+
+  if (!synthetic) {
+    if (acc.name.startsWith("__cp_")) {
+      // Upstream hallucinated a __cp_* name we never declared.
+      return {
+        item: buildFunctionCallItem(acc, "incomplete"),
+        failedSynthetic: true,
+        failed: {
+          code: "undeclared_synthetic_tool",
+          message: `Upstream emitted a call to undeclared synthetic tool "${acc.name}".`,
+        },
+      }
+    }
+    // Plain function call. Don't validate arguments shape; pass through.
+    return { item: buildFunctionCallItem(acc, "completed") }
+  }
+
+  // Synthetic family: must parse + validate shape.
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(acc.argumentsBuffer)
+  } catch {
+    return {
+      item: buildFunctionCallItem(acc, "incomplete"),
+      failedSynthetic: true,
+      failed: {
+        code: "upstream_malformed_tool_arguments",
+        message: `Upstream tool call for "${acc.name}" had unparseable JSON arguments.`,
+      },
+    }
+  }
+
+  if (synthetic.family === "local_shell") {
+    if (!isLocalShellAction(parsed)) {
+      return {
+        item: buildFunctionCallItem(acc, "incomplete"),
+        failedSynthetic: true,
+        failed: {
+          code: "upstream_malformed_tool_arguments",
+          message: `Upstream tool call for "${acc.name}" did not match LocalShellAction shape.`,
+        },
+      }
+    }
+    const item: ResponsesOutputLocalShellCall = {
+      type: "local_shell_call",
+      id: acc.itemId,
+      call_id: acc.callId,
+      action: parsed,
+      status: "completed",
+    }
+    return { item }
+  }
+
+  // custom: shape is { input: string }.
+  if (
+    typeof parsed !== "object"
+    || parsed === null
+    || typeof (parsed as { input?: unknown }).input !== "string"
+  ) {
+    return {
+      item: buildFunctionCallItem(acc, "incomplete"),
+      failedSynthetic: true,
+      failed: {
+        code: "upstream_malformed_tool_arguments",
+        message: `Upstream tool call for "${acc.name}" did not match {input: string} shape.`,
+      },
+    }
+  }
+  const item: ResponsesOutputCustomToolCall = {
+    type: "custom_tool_call",
+    id: acc.itemId,
+    call_id: acc.callId,
+    name: synthetic.originalName ?? acc.name,
+    input: (parsed as { input: string }).input,
+    status: "completed",
+  }
+  return { item }
+}
+
+function isLocalShellAction(
+  value: unknown,
+): value is ResponsesLocalShellAction {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  if (!Array.isArray(v.command)) return false
+  if (!v.command.every((c) => typeof c === "string")) return false
+  if (v.workdir !== undefined && typeof v.workdir !== "string") return false
+  if (v.timeout_ms !== undefined && typeof v.timeout_ms !== "number") {
+    return false
+  }
+  if (v.env !== undefined) {
+    if (typeof v.env !== "object" || v.env === null) return false
+    for (const val of Object.values(v.env as Record<string, unknown>)) {
+      if (typeof val !== "string") return false
+    }
+  }
+  return true
+}
+
+// ----- Envelope builder ---------------------------------------------------
+
+interface BuildEnvelopeOptions {
+  ctx: ResponsesStreamContext
+  status: "in_progress" | "completed" | "incomplete" | "failed"
+  output: Array<ResponsesOutputItem>
+  usage: ResponsesUsage | undefined
+  error?: { code: string; message: string }
+  incompleteDetails?: ResponsesIncompleteDetails
+}
+
+function buildEnvelope(opts: BuildEnvelopeOptions): ResponsesEnvelope {
+  const { ctx, status, output, usage, error, incompleteDetails } = opts
+  return {
+    id: ctx.responseId,
+    object: "response",
+    created_at: ctx.createdAt,
+    status,
+    model: ctx.model,
+    output,
+    ...(usage && { usage }),
+    ...(incompleteDetails && { incomplete_details: incompleteDetails }),
+    ...(error && { error }),
+  }
+}
+
+// ----- Post-`response.created` error helper -------------------------------
+
+export function translateStreamErrorToResponsesEvent(
+  err: unknown,
+  ctx: ResponsesStreamContext,
+): ResponsesStreamEvent {
+  const message =
+    err instanceof Error ? err.message : "An unexpected error occurred."
+  return {
+    type: "response.failed",
+    response: buildEnvelope({
+      ctx,
+      status: "failed",
+      output: [],
+      usage: undefined,
+      error: { code: "stream_interrupted", message },
+    }),
+  }
+}
+
+// ----- Non-streaming envelope synthesis -----------------------------------
+
+// eslint-disable-next-line max-lines-per-function
+export function translateNonStreamingResponse(
+  response: ChatCompletionResponse,
+  ctx: ResponsesStreamContext,
+): ResponsesEnvelope {
+  // We feed the non-streaming response through the same accumulator logic
+  // by synthesizing a single chunk + a terminal chunk — keeps validation /
+  // raise / failed-on-malformed semantics identical to the streaming path.
+  const choice = response.choices[0]
+  const synthChunks: Array<ChatCompletionChunk> = []
+  if (choice.message.content) {
+    synthChunks.push({
+      id: response.id,
+      object: "chat.completion.chunk",
+      created: response.created,
+      model: response.model,
+      choices: [
+        {
+          index: 0,
+          delta: { content: choice.message.content },
+          finish_reason: null,
+          logprobs: null,
+        },
+      ],
+    })
+  }
+  if (choice.message.tool_calls) {
+    for (let i = 0; i < choice.message.tool_calls.length; i++) {
+      const tc = choice.message.tool_calls[i]
+      synthChunks.push(
+        {
+          id: response.id,
+          object: "chat.completion.chunk",
+          created: response.created,
+          model: response.model,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: i,
+                    id: tc.id,
+                    type: "function",
+                    function: { name: tc.function.name, arguments: "" },
+                  },
+                ],
+              },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        },
+        {
+          id: response.id,
+          object: "chat.completion.chunk",
+          created: response.created,
+          model: response.model,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  { index: i, function: { arguments: tc.function.arguments } },
+                ],
+              },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        },
+      )
+    }
+  }
+  synthChunks.push({
+    id: response.id,
+    object: "chat.completion.chunk",
+    created: response.created,
+    model: response.model,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: choice.finish_reason,
+        logprobs: null,
+      },
+    ],
+    ...(response.usage && { usage: { ...response.usage } }),
+  })
+
+  const state = createInitialStreamState()
+  const events: Array<ResponsesStreamEvent> = []
+  for (const c of synthChunks) {
+    events.push(...translateChunkToResponsesEvents(c, state, ctx))
+  }
+
+  // The terminal envelope is the response.completed (or response.failed).
+  const terminal = events.find(
+    (e) => e.type === "response.completed" || e.type === "response.failed",
+  )
+  if (terminal) {
+    return terminal.response
+  }
+  return buildEnvelope({
+    ctx,
+    status: "completed",
+    output: [],
+    usage: state.usage,
+  })
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { completionRoutes } from "./routes/chat-completions/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
 import { modelRoutes } from "./routes/models/route"
+import { responseRoutes } from "./routes/responses/route"
 import { tokenRoute } from "./routes/token/route"
 import { usageRoute } from "./routes/usage/route"
 
@@ -21,11 +22,13 @@ server.route("/models", modelRoutes)
 server.route("/embeddings", embeddingRoutes)
 server.route("/usage", usageRoute)
 server.route("/token", tokenRoute)
+server.route("/responses", responseRoutes)
 
 // Compatibility with tools that expect v1/ prefix
 server.route("/v1/chat/completions", completionRoutes)
 server.route("/v1/models", modelRoutes)
 server.route("/v1/embeddings", embeddingRoutes)
+server.route("/v1/responses", responseRoutes)
 
 // Anthropic compatible endpoints
 server.route("/v1/messages", messageRoutes)

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -148,6 +148,11 @@ export interface ChatCompletionsPayload {
     | { type: "function"; function: { name: string } }
     | null
   user?: string | null
+
+  // GitHub Copilot CAPI extension for Anthropic models (mirrors vscode-copilot-chat
+  // IEndpointBody.thinking_budget). Flat top-level integer; Copilot's broker
+  // forwards it as Anthropic's `thinking.budget_tokens` upstream.
+  thinking_budget?: number | null
 }
 
 export interface Tool {

--- a/tests/responses-pre-stream-errors.test.ts
+++ b/tests/responses-pre-stream-errors.test.ts
@@ -1,0 +1,146 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test"
+
+import { state } from "../src/lib/state"
+import { responseRoutes } from "../src/routes/responses/route"
+
+// Minimal in-memory fetch mock used by createChatCompletions.
+state.copilotToken = "test-token"
+state.vsCodeVersion = "1.0.0"
+state.accountType = "individual"
+
+interface FetchMockResult {
+  ok?: boolean
+  status?: number
+  text?: string
+  json?: unknown
+}
+
+let nextFetchResult: FetchMockResult = { ok: true, status: 200, json: {} }
+
+const fetchMock = mock(() => {
+  const r = nextFetchResult
+  return Promise.resolve({
+    ok: r.ok ?? true,
+    status: r.status ?? 200,
+    headers: new Headers(),
+    text: () => Promise.resolve(r.text ?? ""),
+    json: () => Promise.resolve(r.json ?? {}),
+  } as unknown as Response)
+})
+;(globalThis as unknown as { fetch: typeof fetch }).fetch =
+  fetchMock as unknown as typeof fetch
+
+async function postResponses(body: unknown): Promise<Response> {
+  return responseRoutes.fetch(
+    new Request("http://test/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+beforeEach(() => {
+  state.manualApprove = false
+  state.rateLimitWait = false
+  state.rateLimitSeconds = undefined
+  state.lastRequestTimestamp = undefined
+  nextFetchResult = { ok: true, status: 200, json: {} }
+})
+
+const minimalRequest = {
+  model: "gpt-5",
+  input: [
+    {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "hi" }],
+    },
+  ],
+}
+
+describe("pre-stream errors", () => {
+  test("rejects previous_response_id with 400 + invalid_request_error", async () => {
+    const res = await postResponses({
+      ...minimalRequest,
+      previous_response_id: "resp_x",
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { type: string; code: string } }
+    expect(body.error.type).toBe("invalid_request_error")
+    expect(body.error.code).toBe("unsupported_responses_field")
+  })
+
+  test("rejects store: true with 400", async () => {
+    const res = await postResponses({ ...minimalRequest, store: true })
+    expect(res.status).toBe(400)
+  })
+
+  test("rejects background: true with 400", async () => {
+    const res = await postResponses({ ...minimalRequest, background: true })
+    expect(res.status).toBe(400)
+  })
+
+  test("rejects reserved tool name in tools[]", async () => {
+    const res = await postResponses({
+      ...minimalRequest,
+      tools: [{ type: "function", name: "__cp_oops", parameters: {} }],
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe("reserved_tool_name")
+  })
+
+  test("rejects reserved tool name in historical input function_call", async () => {
+    const res = await postResponses({
+      ...minimalRequest,
+      input: [
+        ...minimalRequest.input,
+        {
+          type: "function_call",
+          call_id: "c1",
+          name: "__cp_evil",
+          arguments: "{}",
+        },
+      ],
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test("rate-limit denial returns 429 envelope", async () => {
+    state.rateLimitSeconds = 60
+    state.lastRequestTimestamp = Date.now()
+    state.rateLimitWait = false
+
+    const res = await postResponses(minimalRequest)
+    expect(res.status).toBe(429)
+  })
+
+  test("upstream non-OK before first chunk → HTTP envelope (not SSE)", async () => {
+    nextFetchResult = {
+      ok: false,
+      status: 502,
+      text: "bad gateway",
+    }
+    const res = await postResponses(minimalRequest)
+    expect(res.status).toBe(502)
+    const body = (await res.json()) as { error: { type: string } }
+    expect(body.error.type).toBe("api_error")
+  })
+
+  test("upstream 401 produces authentication_error", async () => {
+    nextFetchResult = { ok: false, status: 401, text: "no auth" }
+    const res = await postResponses(minimalRequest)
+    expect(res.status).toBe(401)
+    const body = (await res.json()) as { error: { type: string } }
+    expect(body.error.type).toBe("authentication_error")
+  })
+
+  test("upstream 429 produces rate_limit_error", async () => {
+    nextFetchResult = { ok: false, status: 429, text: "slow down" }
+    const res = await postResponses(minimalRequest)
+    expect(res.status).toBe(429)
+    const body = (await res.json()) as { error: { type: string } }
+    expect(body.error.type).toBe("rate_limit_error")
+  })
+})

--- a/tests/responses-request.test.ts
+++ b/tests/responses-request.test.ts
@@ -1,0 +1,534 @@
+import { describe, test, expect } from "bun:test"
+
+import {
+  ResponsesValidationError,
+  translateResponsesToOpenAI,
+} from "../src/routes/responses/request-translation"
+import { type ResponsesRequest } from "../src/routes/responses/responses-types"
+
+function basePayload(
+  overrides: Partial<ResponsesRequest> = {},
+): ResponsesRequest {
+  return {
+    model: "gpt-5",
+    input: [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hello" }],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe("translateResponsesToOpenAI - basic shapes", () => {
+  test("translates a minimal text-only payload", () => {
+    const { payload, syntheticToolMap } =
+      translateResponsesToOpenAI(basePayload())
+    expect(payload.model).toBe("gpt-5")
+    expect(payload.messages).toEqual([{ role: "user", content: "hello" }])
+    expect(syntheticToolMap.size).toBe(0)
+  })
+
+  test("forwards instructions as a system message", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({ instructions: "be terse" }),
+    )
+    expect(payload.messages[0]).toEqual({
+      role: "system",
+      content: "be terse",
+    })
+    expect(payload.messages[1]).toEqual({ role: "user", content: "hello" })
+  })
+
+  test("maps developer role to system", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        input: [
+          {
+            type: "message",
+            role: "developer",
+            content: [{ type: "input_text", text: "rules" }],
+          },
+        ],
+      }),
+    )
+    expect(payload.messages[0].role).toBe("system")
+  })
+
+  test("emits image content parts when an input_image is present", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [
+              { type: "input_text", text: "look" },
+              {
+                type: "input_image",
+                image_url: "https://example.com/x.png",
+                detail: "high",
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const content = payload.messages[0].content
+    expect(Array.isArray(content)).toBe(true)
+    if (Array.isArray(content)) {
+      expect(content[0]).toEqual({ type: "text", text: "look" })
+      expect(content[1]).toEqual({
+        type: "image_url",
+        image_url: { url: "https://example.com/x.png", detail: "high" },
+      })
+    }
+  })
+
+  test("forwards metadata.user_id as user", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({ metadata: { user_id: "u_123" } }),
+    )
+    expect(payload.user).toBe("u_123")
+  })
+})
+
+describe("translateResponsesToOpenAI - tool lowering", () => {
+  test("function tool passes through verbatim", () => {
+    const { payload, syntheticToolMap } = translateResponsesToOpenAI(
+      basePayload({
+        tools: [
+          {
+            type: "function",
+            name: "search",
+            description: "do a search",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      }),
+    )
+    expect(payload.tools).toHaveLength(1)
+    expect(payload.tools?.[0]).toEqual({
+      type: "function",
+      function: {
+        name: "search",
+        description: "do a search",
+        parameters: { type: "object", properties: {} },
+      },
+    })
+    expect(syntheticToolMap.size).toBe(0)
+  })
+
+  test("local_shell lowers to __cp_local_shell with mapping", () => {
+    const { payload, syntheticToolMap } = translateResponsesToOpenAI(
+      basePayload({ tools: [{ type: "local_shell" }] }),
+    )
+    expect(payload.tools).toHaveLength(1)
+    expect(payload.tools?.[0].function.name).toBe("__cp_local_shell")
+    expect(syntheticToolMap.get("__cp_local_shell")?.family).toBe("local_shell")
+  })
+
+  test("custom tool lowers to __cp_custom_<n> with original name retained", () => {
+    const { payload, syntheticToolMap } = translateResponsesToOpenAI(
+      basePayload({
+        tools: [
+          { type: "custom", name: "my_tool", description: "my desc" },
+          { type: "custom", name: "other_tool" },
+        ],
+      }),
+    )
+    expect(payload.tools?.[0].function.name).toBe("__cp_custom_0")
+    expect(payload.tools?.[1].function.name).toBe("__cp_custom_1")
+    expect(syntheticToolMap.get("__cp_custom_0")).toEqual({
+      family: "custom",
+      originalName: "my_tool",
+    })
+    expect(syntheticToolMap.get("__cp_custom_1")).toEqual({
+      family: "custom",
+      originalName: "other_tool",
+    })
+  })
+
+  test("web_search tool is silently dropped", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({ tools: [{ type: "web_search" }] }),
+    )
+    expect(payload.tools).toBeUndefined()
+  })
+
+  test("rejects user-declared __cp_*-prefixed function tool", () => {
+    expect(() =>
+      translateResponsesToOpenAI(
+        basePayload({
+          tools: [{ type: "function", name: "__cp_evil", parameters: {} }],
+        }),
+      ),
+    ).toThrow(ResponsesValidationError)
+  })
+
+  test("rejects __cp_*-prefixed historical function_call", () => {
+    expect(() =>
+      translateResponsesToOpenAI(
+        basePayload({
+          input: [
+            {
+              type: "function_call",
+              call_id: "c1",
+              name: "__cp_evil",
+              arguments: "{}",
+            },
+          ],
+        }),
+      ),
+    ).toThrow(ResponsesValidationError)
+  })
+})
+
+describe("translateResponsesToOpenAI - tool_choice", () => {
+  test("string tool_choice passes through", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({ tool_choice: "auto" }),
+    )
+    expect(payload.tool_choice).toBe("auto")
+  })
+
+  test("function tool_choice maps to {type:function,function:{name}}", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        tools: [{ type: "function", name: "search", parameters: {} }],
+        tool_choice: { type: "function", name: "search" },
+      }),
+    )
+    expect(payload.tool_choice).toEqual({
+      type: "function",
+      function: { name: "search" },
+    })
+  })
+
+  test("custom tool_choice resolves to synthetic name", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        tools: [{ type: "custom", name: "my_tool" }],
+        tool_choice: { type: "custom", name: "my_tool" },
+      }),
+    )
+    expect(payload.tool_choice).toEqual({
+      type: "function",
+      function: { name: "__cp_custom_0" },
+    })
+  })
+
+  test("allowed_tools with single match pins that tool", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        tools: [
+          { type: "function", name: "a", parameters: {} },
+          { type: "function", name: "b", parameters: {} },
+        ],
+        tool_choice: {
+          type: "allowed_tools",
+          tools: [{ type: "function", name: "a" }],
+        },
+      }),
+    )
+    expect(payload.tool_choice).toEqual({
+      type: "function",
+      function: { name: "a" },
+    })
+  })
+
+  test("allowed_tools with multiple matches falls back to mode", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        tools: [
+          { type: "function", name: "a", parameters: {} },
+          { type: "function", name: "b", parameters: {} },
+        ],
+        tool_choice: {
+          type: "allowed_tools",
+          mode: "required",
+          tools: [
+            { type: "function", name: "a" },
+            { type: "function", name: "b" },
+          ],
+        },
+      }),
+    )
+    expect(payload.tool_choice).toBe("required")
+  })
+
+  test("allowed_tools resolves local_shell to synthetic", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        tools: [{ type: "local_shell" }],
+        tool_choice: {
+          type: "allowed_tools",
+          tools: ["local_shell"],
+        },
+      }),
+    )
+    expect(payload.tool_choice).toEqual({
+      type: "function",
+      function: { name: "__cp_local_shell" },
+    })
+  })
+
+  test("rejects allowed_tools referencing unknown function", () => {
+    expect(() =>
+      translateResponsesToOpenAI(
+        basePayload({
+          tools: [{ type: "function", name: "a", parameters: {} }],
+          tool_choice: {
+            type: "allowed_tools",
+            tools: [{ type: "function", name: "missing" }],
+          },
+        }),
+      ),
+    ).toThrow(ResponsesValidationError)
+  })
+
+  test("rejects allowed_tools with empty tool list", () => {
+    try {
+      translateResponsesToOpenAI(
+        basePayload({
+          tools: [{ type: "function", name: "a", parameters: {} }],
+          tool_choice: {
+            type: "allowed_tools",
+            tools: [],
+          },
+        }),
+      )
+      throw new Error("expected to throw")
+    } catch (e) {
+      expect(e).toBeInstanceOf(ResponsesValidationError)
+      expect((e as ResponsesValidationError).code).toBe("empty_allowed_tools")
+    }
+  })
+
+  test("rejects allowed_tools referencing web_search", () => {
+    try {
+      translateResponsesToOpenAI(
+        basePayload({
+          tool_choice: {
+            type: "allowed_tools",
+            tools: [
+              { type: "function", name: "x" } as never,
+              { type: "web_search" } as never,
+            ],
+          },
+        }),
+      )
+      throw new Error("expected to throw")
+    } catch (e) {
+      expect(e).toBeInstanceOf(ResponsesValidationError)
+      expect(
+        ["unknown_tool_in_choice", "unsupported_tool_in_choice"].includes(
+          (e as ResponsesValidationError).code,
+        ),
+      ).toBe(true)
+    }
+  })
+})
+
+describe("translateResponsesToOpenAI - reasoning effort → thinking_budget", () => {
+  test("only applied for claude- models", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({ model: "gpt-5", reasoning: { effort: "high" } }),
+    )
+    expect(payload.thinking_budget).toBeUndefined()
+  })
+
+  test("maps low/medium/high to anchored budgets for claude- models", () => {
+    const low = translateResponsesToOpenAI(
+      basePayload({ model: "claude-sonnet-4-5", reasoning: { effort: "low" } }),
+    ).payload
+    const medium = translateResponsesToOpenAI(
+      basePayload({
+        model: "claude-sonnet-4-5",
+        reasoning: { effort: "medium" },
+      }),
+    ).payload
+    const high = translateResponsesToOpenAI(
+      basePayload({
+        model: "claude-sonnet-4-5",
+        reasoning: { effort: "high" },
+      }),
+    ).payload
+    expect(low.thinking_budget).toBe(4000)
+    expect(medium.thinking_budget).toBe(10000)
+    expect(high.thinking_budget).toBe(31999)
+  })
+
+  test("minimal effort keeps thinking off", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        model: "claude-sonnet-4-5",
+        reasoning: { effort: "minimal" },
+      }),
+    )
+    expect(payload.thinking_budget).toBeUndefined()
+  })
+
+  test("clamps thinking_budget to max_output_tokens - 1", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        model: "claude-sonnet-4-5",
+        reasoning: { effort: "high" },
+        max_output_tokens: 1000,
+      }),
+    )
+    expect(payload.thinking_budget).toBe(999)
+  })
+
+  test("dropping temperature/top_p when thinking is on", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        model: "claude-sonnet-4-5",
+        reasoning: { effort: "high" },
+        temperature: 0.7,
+        top_p: 0.9,
+      }),
+    )
+    expect(payload.temperature).toBeUndefined()
+    expect(payload.top_p).toBeUndefined()
+  })
+})
+
+describe("translateResponsesToOpenAI - input lowering", () => {
+  test("coalesces consecutive function_call items into one assistant msg", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "go" }],
+          },
+          {
+            type: "function_call",
+            call_id: "c1",
+            name: "a",
+            arguments: "{}",
+          },
+          {
+            type: "function_call",
+            call_id: "c2",
+            name: "b",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: "c1",
+            output: "ok",
+          },
+        ],
+      }),
+    )
+    // user, assistant(tool_calls=[c1,c2]), tool(c1)
+    expect(payload.messages).toHaveLength(3)
+    expect(payload.messages[1].role).toBe("assistant")
+    expect(payload.messages[1].tool_calls).toHaveLength(2)
+    expect(payload.messages[2]).toEqual({
+      role: "tool",
+      tool_call_id: "c1",
+      content: "ok",
+    })
+  })
+
+  test("local_shell_call lowers to assistant tool_call with synthetic name", () => {
+    const { payload, syntheticToolMap } = translateResponsesToOpenAI(
+      basePayload({
+        input: [
+          {
+            type: "local_shell_call",
+            call_id: "lsc1",
+            action: { type: "exec", command: ["ls"] },
+          },
+        ],
+      }),
+    )
+    expect(payload.messages[0].tool_calls?.[0].function.name).toBe(
+      "__cp_local_shell",
+    )
+    expect(syntheticToolMap.has("__cp_local_shell")).toBe(true)
+  })
+
+  test("custom_tool_call without declared tool falls back to plain function call", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        input: [
+          {
+            type: "custom_tool_call",
+            call_id: "ctc1",
+            name: "unmapped",
+            input: "raw",
+          },
+        ],
+      }),
+    )
+    const tc = payload.messages[0].tool_calls?.[0]
+    expect(tc?.function.name).toBe("unmapped")
+    expect(JSON.parse(tc?.function.arguments ?? "{}")).toEqual({
+      input: "raw",
+    })
+  })
+
+  test("custom_tool_call with declared tool uses synthetic name", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        tools: [{ type: "custom", name: "my_tool" }],
+        input: [
+          {
+            type: "custom_tool_call",
+            call_id: "ctc1",
+            name: "my_tool",
+            input: "raw",
+          },
+        ],
+      }),
+    )
+    const tc = payload.messages[0].tool_calls?.[0]
+    expect(tc?.function.name).toBe("__cp_custom_0")
+  })
+
+  test("reasoning items are dropped", () => {
+    const { payload } = translateResponsesToOpenAI(
+      basePayload({
+        input: [
+          { type: "reasoning", summary: "thinking…" },
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "hi" }],
+          },
+        ],
+      }),
+    )
+    expect(payload.messages).toHaveLength(1)
+    expect(payload.messages[0].role).toBe("user")
+  })
+})
+
+describe("translateResponsesToOpenAI - rejected continuation features", () => {
+  test("previous_response_id is rejected", () => {
+    expect(() =>
+      translateResponsesToOpenAI(
+        basePayload({ previous_response_id: "resp_x" }),
+      ),
+    ).toThrow(ResponsesValidationError)
+  })
+
+  test("store: true is rejected", () => {
+    expect(() =>
+      translateResponsesToOpenAI(basePayload({ store: true })),
+    ).toThrow(ResponsesValidationError)
+  })
+
+  test("background: true is rejected", () => {
+    expect(() =>
+      translateResponsesToOpenAI(basePayload({ background: true })),
+    ).toThrow(ResponsesValidationError)
+  })
+})

--- a/tests/responses-stream.test.ts
+++ b/tests/responses-stream.test.ts
@@ -1,0 +1,438 @@
+import { describe, test, expect } from "bun:test"
+
+import { type SyntheticToolMap } from "../src/routes/responses/request-translation"
+import {
+  createInitialStreamState,
+  finalizeStream,
+  translateChunkToResponsesEvents,
+  type ResponsesStreamContext,
+} from "../src/routes/responses/stream-translation"
+import { type ChatCompletionChunk } from "../src/services/copilot/create-chat-completions"
+
+function ctx(map: SyntheticToolMap = new Map()): ResponsesStreamContext {
+  return {
+    responseId: "resp_test",
+    model: "gpt-5",
+    createdAt: 1_700_000_000,
+    syntheticToolMap: map,
+  }
+}
+
+function chunk(
+  delta: NonNullable<ChatCompletionChunk["choices"]>[number]["delta"],
+  finishReason:
+    | ChatCompletionChunk["choices"][number]["finish_reason"]
+    | null = null,
+  usage?: ChatCompletionChunk["usage"],
+): ChatCompletionChunk {
+  return {
+    id: "c0",
+    object: "chat.completion.chunk",
+    created: 0,
+    model: "gpt-5",
+    choices: [{ index: 0, delta, finish_reason: finishReason, logprobs: null }],
+    ...(usage && { usage }),
+  }
+}
+
+function runChunks(
+  chunks: Array<ChatCompletionChunk>,
+  c: ResponsesStreamContext = ctx(),
+) {
+  const state = createInitialStreamState()
+  const events = []
+  for (const ch of chunks) {
+    events.push(...translateChunkToResponsesEvents(ch, state, c))
+  }
+  return { state, events }
+}
+
+describe("stream translation - text only", () => {
+  test("emits created/in_progress, deltas, output_item.done, completed", () => {
+    const { events } = runChunks([
+      chunk({ content: "Hel" }),
+      chunk({ content: "lo" }),
+      chunk({}, "stop"),
+    ])
+    const types = events.map((e) => e.type)
+    expect(types[0]).toBe("response.created")
+    expect(types[1]).toBe("response.in_progress")
+    expect(types).toContain("response.output_item.added")
+    expect(
+      types.filter((t) => t === "response.output_text.delta"),
+    ).toHaveLength(2)
+    expect(types).toContain("response.output_item.done")
+    expect(types.at(-1)).toBe("response.completed")
+
+    const completed = events.at(-1)
+    if (completed?.type === "response.completed") {
+      expect(completed.response.status).toBe("completed")
+      const item = completed.response.output[0]
+      if (item.type === "message") {
+        expect(item.content[0].text).toBe("Hello")
+      }
+    }
+  })
+})
+
+describe("stream translation - tool calls", () => {
+  test("single function call passes args through", () => {
+    const { events } = runChunks([
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_1",
+            type: "function",
+            function: { name: "search", arguments: "" },
+          },
+        ],
+      }),
+      chunk({
+        tool_calls: [{ index: 0, function: { arguments: '{"q":"hi"}' } }],
+      }),
+      chunk({}, "tool_calls"),
+    ])
+    const done = events.find((e) => e.type === "response.output_item.done")
+    if (done?.type === "response.output_item.done") {
+      const item = done.item
+      if (item.type === "function_call") {
+        expect(item.name).toBe("search")
+        expect(item.arguments).toBe('{"q":"hi"}')
+        expect(item.call_id).toBe("call_1")
+      }
+    }
+  })
+
+  test("parallel function calls produce two output items", () => {
+    const { events } = runChunks([
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "c1",
+            type: "function",
+            function: { name: "a", arguments: "{}" },
+          },
+          {
+            index: 1,
+            id: "c2",
+            type: "function",
+            function: { name: "b", arguments: "{}" },
+          },
+        ],
+      }),
+      chunk({}, "tool_calls"),
+    ])
+    const dones = events.filter((e) => e.type === "response.output_item.done")
+    expect(dones).toHaveLength(2)
+  })
+
+  test("local_shell raise: synthetic name → local_shell_call item", () => {
+    const map: SyntheticToolMap = new Map([
+      ["__cp_local_shell", { family: "local_shell" }],
+    ])
+    const { events } = runChunks(
+      [
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: "lsc1",
+              type: "function",
+              function: {
+                name: "__cp_local_shell",
+                arguments: '{"command":["ls","-la"]}',
+              },
+            },
+          ],
+        }),
+        chunk({}, "tool_calls"),
+      ],
+      ctx(map),
+    )
+    const done = events.find((e) => e.type === "response.output_item.done")
+    if (done?.type === "response.output_item.done") {
+      expect(done.item.type).toBe("local_shell_call")
+      if (done.item.type === "local_shell_call") {
+        expect(done.item.action.command).toEqual(["ls", "-la"])
+      }
+    }
+  })
+
+  test("custom tool raise: synthetic → custom_tool_call with original name", () => {
+    const map: SyntheticToolMap = new Map([
+      ["__cp_custom_0", { family: "custom", originalName: "my_tool" }],
+    ])
+    const { events } = runChunks(
+      [
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: "ctc1",
+              type: "function",
+              function: {
+                name: "__cp_custom_0",
+                arguments: '{"input":"raw text"}',
+              },
+            },
+          ],
+        }),
+        chunk({}, "tool_calls"),
+      ],
+      ctx(map),
+    )
+    const done = events.find((e) => e.type === "response.output_item.done")
+    if (done?.type === "response.output_item.done") {
+      expect(done.item.type).toBe("custom_tool_call")
+      if (done.item.type === "custom_tool_call") {
+        expect(done.item.name).toBe("my_tool")
+        expect(done.item.input).toBe("raw text")
+      }
+    }
+  })
+})
+
+describe("stream translation - error / failure paths", () => {
+  test("malformed args on plain function call passes through", () => {
+    const { events } = runChunks([
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "c1",
+            type: "function",
+            function: { name: "search", arguments: "{not json" },
+          },
+        ],
+      }),
+      chunk({}, "tool_calls"),
+    ])
+    const done = events.find((e) => e.type === "response.output_item.done")
+    expect(done).toBeDefined()
+    const completed = events.find((e) => e.type === "response.completed")
+    expect(completed).toBeDefined()
+  })
+
+  test("malformed args on synthetic local_shell → response.failed", () => {
+    const map: SyntheticToolMap = new Map([
+      ["__cp_local_shell", { family: "local_shell" }],
+    ])
+    const { events } = runChunks(
+      [
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: "lsc1",
+              type: "function",
+              function: {
+                name: "__cp_local_shell",
+                arguments: "garbage",
+              },
+            },
+          ],
+        }),
+        chunk({}, "tool_calls"),
+      ],
+      ctx(map),
+    )
+    const failed = events.find((e) => e.type === "response.failed")
+    expect(failed).toBeDefined()
+    if (failed?.type === "response.failed") {
+      expect(failed.response.error?.code).toBe(
+        "upstream_malformed_tool_arguments",
+      )
+    }
+    expect(events.find((e) => e.type === "response.completed")).toBeUndefined()
+  })
+
+  test("malformed shape on synthetic custom → response.failed", () => {
+    const map: SyntheticToolMap = new Map([
+      ["__cp_custom_0", { family: "custom", originalName: "my_tool" }],
+    ])
+    const { events } = runChunks(
+      [
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: "ctc1",
+              type: "function",
+              function: {
+                name: "__cp_custom_0",
+                arguments: '{"wrong":"shape"}',
+              },
+            },
+          ],
+        }),
+        chunk({}, "tool_calls"),
+      ],
+      ctx(map),
+    )
+    const failed = events.find((e) => e.type === "response.failed")
+    expect(failed).toBeDefined()
+  })
+
+  test("undeclared __cp_* from upstream → response.failed", () => {
+    const { events } = runChunks([
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "x1",
+            type: "function",
+            function: { name: "__cp_unknown", arguments: "{}" },
+          },
+        ],
+      }),
+      chunk({}, "tool_calls"),
+    ])
+    const failed = events.find((e) => e.type === "response.failed")
+    expect(failed).toBeDefined()
+    if (failed?.type === "response.failed") {
+      expect(failed.response.error?.code).toBe("undeclared_synthetic_tool")
+    }
+  })
+})
+
+describe("stream translation - finish_reason mapping", () => {
+  test("stop → completed", () => {
+    const { events } = runChunks([chunk({ content: "ok" }), chunk({}, "stop")])
+    const completed = events.find((e) => e.type === "response.completed")
+    if (completed?.type === "response.completed") {
+      expect(completed.response.status).toBe("completed")
+    }
+  })
+
+  test("tool_calls → completed", () => {
+    const { events } = runChunks([
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "c1",
+            type: "function",
+            function: { name: "a", arguments: "{}" },
+          },
+        ],
+      }),
+      chunk({}, "tool_calls"),
+    ])
+    const completed = events.find((e) => e.type === "response.completed")
+    if (completed?.type === "response.completed") {
+      expect(completed.response.status).toBe("completed")
+    }
+  })
+
+  test("length → incomplete + max_output_tokens", () => {
+    const { events } = runChunks([chunk({ content: "x" }), chunk({}, "length")])
+    const completed = events.find((e) => e.type === "response.completed")
+    if (completed?.type === "response.completed") {
+      expect(completed.response.status).toBe("incomplete")
+      expect(completed.response.incomplete_details?.reason).toBe(
+        "max_output_tokens",
+      )
+    }
+  })
+
+  test("content_filter → incomplete + content_filter", () => {
+    const { events } = runChunks([
+      chunk({ content: "x" }),
+      chunk({}, "content_filter"),
+    ])
+    const completed = events.find((e) => e.type === "response.completed")
+    if (completed?.type === "response.completed") {
+      expect(completed.response.incomplete_details?.reason).toBe(
+        "content_filter",
+      )
+    }
+  })
+})
+
+describe("stream translation - transport-cut handling", () => {
+  test("text-only mid-stream cut emits valid item + incomplete completion", () => {
+    const state = createInitialStreamState()
+    const c = ctx()
+    const events = [
+      ...translateChunkToResponsesEvents(
+        chunk({ content: "partial" }),
+        state,
+        c,
+      ),
+      ...finalizeStream(state, c, { transportCut: true }),
+    ]
+    const dones = events.filter((e) => e.type === "response.output_item.done")
+    expect(dones).toHaveLength(1)
+    const completed = events.find((e) => e.type === "response.completed")
+    if (completed?.type === "response.completed") {
+      expect(completed.response.status).toBe("incomplete")
+    }
+  })
+
+  test("parallel cut with one valid + one malformed synthetic emits ONLY response.failed", () => {
+    const map: SyntheticToolMap = new Map([
+      ["__cp_local_shell", { family: "local_shell" }],
+    ])
+    const state = createInitialStreamState()
+    const c = ctx(map)
+    const events = [
+      ...translateChunkToResponsesEvents(
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: "c_valid",
+              type: "function",
+              function: { name: "search", arguments: '{"q":"x"}' },
+            },
+            {
+              index: 1,
+              id: "c_bad",
+              type: "function",
+              function: {
+                name: "__cp_local_shell",
+                arguments: "broken",
+              },
+            },
+          ],
+        }),
+        state,
+        c,
+      ),
+      ...finalizeStream(state, c, { transportCut: true }),
+    ]
+    const dones = events.filter((e) => e.type === "response.output_item.done")
+    expect(dones).toHaveLength(0)
+    const failed = events.find((e) => e.type === "response.failed")
+    expect(failed).toBeDefined()
+    if (failed?.type === "response.failed") {
+      expect(failed.response.error?.code).toBe(
+        "stream_interrupted_malformed_tool_arguments",
+      )
+    }
+    expect(events.find((e) => e.type === "response.completed")).toBeUndefined()
+  })
+})
+
+describe("stream translation - usage propagation", () => {
+  test("usage from terminal chunk surfaces in response.completed", () => {
+    const { events } = runChunks([
+      chunk({ content: "hi" }),
+      chunk({}, "stop", {
+        prompt_tokens: 12,
+        completion_tokens: 3,
+        total_tokens: 15,
+      }),
+    ])
+    const completed = events.find((e) => e.type === "response.completed")
+    if (completed?.type === "response.completed") {
+      expect(completed.response.usage).toEqual({
+        input_tokens: 12,
+        output_tokens: 3,
+        total_tokens: 15,
+      })
+    }
+  })
+})

--- a/tests/thinking-keywords.test.ts
+++ b/tests/thinking-keywords.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+
+import type {
+  AnthropicMessage,
+  AnthropicUserMessage,
+} from "~/routes/messages/anthropic-types"
+
+import { detectKeywordBudget } from "../src/routes/messages/non-stream-translation"
+
+const userText = (text: string): AnthropicUserMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+})
+
+const userString = (text: string): AnthropicUserMessage => ({
+  role: "user",
+  content: text,
+})
+
+describe("detectKeywordBudget", () => {
+  test("bare `think` at start of message → 4000", () => {
+    expect(detectKeywordBudget([userText("think about this")])).toBe(4000)
+  })
+
+  test("bare `think` mid-sentence → undefined", () => {
+    expect(
+      detectKeywordBudget([userText("I think we should refactor")]),
+    ).toBeUndefined()
+  })
+
+  test("`think hard` → 10000", () => {
+    expect(detectKeywordBudget([userText("think hard about X")])).toBe(10000)
+  })
+
+  test("`megathink` anywhere → 10000", () => {
+    expect(detectKeywordBudget([userText("please megathink this one")])).toBe(
+      10000,
+    )
+  })
+
+  test("`ultrathink` → 31999", () => {
+    expect(detectKeywordBudget([userText("ultrathink: refactor")])).toBe(31999)
+  })
+
+  test("`think harder` → 31999", () => {
+    expect(detectKeywordBudget([userText("think harder about it")])).toBe(31999)
+  })
+
+  test("highest budget wins when multiple keywords present", () => {
+    expect(detectKeywordBudget([userText("think hard, then ultrathink")])).toBe(
+      31999,
+    )
+  })
+
+  test("no keyword → undefined", () => {
+    expect(detectKeywordBudget([userText("just do X")])).toBeUndefined()
+  })
+
+  test("substring `thinking` does not trigger (word boundary)", () => {
+    expect(detectKeywordBudget([userText("thinking about it")])).toBeUndefined()
+  })
+
+  test("string-form user content is supported", () => {
+    expect(detectKeywordBudget([userString("ultrathink please")])).toBe(31999)
+  })
+
+  test("empty messages → undefined", () => {
+    expect(detectKeywordBudget([])).toBeUndefined()
+  })
+
+  test("only assistant/system messages → undefined", () => {
+    const messages: Array<AnthropicMessage> = [
+      { role: "assistant", content: "ultrathink" },
+    ]
+    expect(detectKeywordBudget(messages)).toBeUndefined()
+  })
+})

--- a/tests/thinking-keywords.test.ts
+++ b/tests/thinking-keywords.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, test } from "bun:test"
 
 import type {
   AnthropicMessage,
+  AnthropicMessagesPayload,
   AnthropicUserMessage,
 } from "~/routes/messages/anthropic-types"
 
-import { detectKeywordBudget } from "../src/routes/messages/non-stream-translation"
+import {
+  detectKeywordBudget,
+  translateToOpenAI,
+} from "../src/routes/messages/non-stream-translation"
 
 const userText = (text: string): AnthropicUserMessage => ({
   role: "user",
@@ -172,5 +176,89 @@ describe("detectKeywordBudget", () => {
   test("trigger outside code block still fires when other text is fenced", () => {
     const text = "ultrathink this:\n```\njust some code\n```\n"
     expect(detectKeywordBudget([userText(text)])).toBe(31999)
+  })
+})
+
+const buildPayload = (
+  overrides: Partial<AnthropicMessagesPayload> = {},
+): AnthropicMessagesPayload => ({
+  model: "claude-sonnet-4",
+  max_tokens: 64000,
+  messages: [userText("hello")],
+  ...overrides,
+})
+
+describe("translateToOpenAI thinking budget", () => {
+  test("no keyword, no payload thinking → no thinking_budget", () => {
+    const out = translateToOpenAI(buildPayload())
+    expect(out.thinking_budget).toBeUndefined()
+  })
+
+  test("keyword only → uses keyword budget", () => {
+    const out = translateToOpenAI(
+      buildPayload({ messages: [userText("ultrathink: refactor")] }),
+    )
+    expect(out.thinking_budget).toBe(31999)
+    expect(out.temperature).toBeUndefined()
+    expect(out.top_p).toBeUndefined()
+  })
+
+  test("payload only → uses payload budget", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        thinking: { type: "enabled", budget_tokens: 8000 },
+      }),
+    )
+    expect(out.thinking_budget).toBe(8000)
+  })
+
+  test("floor: keyword < payload → payload wins", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        messages: [userText("think about it")],
+        thinking: { type: "enabled", budget_tokens: 10000 },
+      }),
+    )
+    expect(out.thinking_budget).toBe(10000)
+  })
+
+  test("floor: keyword > payload → keyword wins", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        messages: [userText("ultrathink the bug")],
+        thinking: { type: "enabled", budget_tokens: 4000 },
+      }),
+    )
+    expect(out.thinking_budget).toBe(31999)
+  })
+
+  test("max_tokens clamps the budget", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        max_tokens: 500,
+        messages: [userText("ultrathink")],
+      }),
+    )
+    expect(out.thinking_budget).toBe(499)
+  })
+
+  test("thinking on drops temperature and top_p", () => {
+    const out = translateToOpenAI(
+      buildPayload({
+        messages: [userText("ultrathink")],
+        temperature: 0.7,
+        top_p: 0.9,
+      }),
+    )
+    expect(out.temperature).toBeUndefined()
+    expect(out.top_p).toBeUndefined()
+  })
+
+  test("no thinking → temperature and top_p preserved", () => {
+    const out = translateToOpenAI(
+      buildPayload({ temperature: 0.7, top_p: 0.9 }),
+    )
+    expect(out.temperature).toBe(0.7)
+    expect(out.top_p).toBe(0.9)
   })
 })

--- a/tests/thinking-keywords.test.ts
+++ b/tests/thinking-keywords.test.ts
@@ -74,4 +74,86 @@ describe("detectKeywordBudget", () => {
     ]
     expect(detectKeywordBudget(messages)).toBeUndefined()
   })
+
+  test("walks back past image-only user turn", () => {
+    const messages: Array<AnthropicMessage> = [
+      userText("ultrathink the bug"),
+      { role: "assistant", content: "ok" },
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "abc",
+            },
+          },
+        ],
+      },
+    ]
+    expect(detectKeywordBudget(messages)).toBe(31999)
+  })
+
+  test("walks back past tool_result-only user turn", () => {
+    const messages: Array<AnthropicMessage> = [
+      userText("ultrathink the refactor"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "read",
+            input: { path: "x" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool_1",
+            content: "file contents",
+          },
+        ],
+      },
+    ]
+    expect(detectKeywordBudget(messages)).toBe(31999)
+  })
+
+  test("sticky across multi-step tool loop", () => {
+    const messages: Array<AnthropicMessage> = [
+      userText("ultrathink: implement feature X"),
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name: "read", input: {} }],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "t1", content: "..." }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t2", name: "edit", input: {} }],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "t2", content: "ok" }],
+      },
+    ]
+    expect(detectKeywordBudget(messages)).toBe(31999)
+  })
+
+  test("all user turns are tool_result/image only → undefined", () => {
+    const messages: Array<AnthropicMessage> = [
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "t1", content: "x" }],
+      },
+    ]
+    expect(detectKeywordBudget(messages)).toBeUndefined()
+  })
 })

--- a/tests/thinking-keywords.test.ts
+++ b/tests/thinking-keywords.test.ts
@@ -156,4 +156,21 @@ describe("detectKeywordBudget", () => {
     ]
     expect(detectKeywordBudget(messages)).toBeUndefined()
   })
+
+  test("`think` inside fenced code block does not trigger", () => {
+    const text = "review this:\n```\nthink about state\n```\n"
+    expect(detectKeywordBudget([userText(text)])).toBeUndefined()
+  })
+
+  test("`ultrathink` inside fenced code block does NOT trigger", () => {
+    // Compound triggers can match anywhere in the message, but fenced code
+    // is stripped first — so they don't fire from inside ``` blocks.
+    const text = "review this:\n```\nultrathink everything\n```\n"
+    expect(detectKeywordBudget([userText(text)])).toBeUndefined()
+  })
+
+  test("trigger outside code block still fires when other text is fenced", () => {
+    const text = "ultrathink this:\n```\njust some code\n```\n"
+    expect(detectKeywordBudget([userText(text)])).toBe(31999)
+  })
 })


### PR DESCRIPTION
## Summary

- Adds an OpenAI Responses-API-compatible endpoint at `/v1/responses` so Codex CLI (v0.87+) can talk to this proxy the same way Claude Code already talks to `/v1/messages`. Both clients can run in parallel against a single instance.
- Translates Responses requests into Copilot's `chat/completions` shape (with `__cp_*` synthetic naming for `local_shell` / `custom` tools, reasoning-effort → `thinking_budget` for Claude models, reserved-name validation, and continuation-feature rejection), then back-translates the streaming chat-completion deltas into a synthetic Responses-API SSE event stream.
- Transport-cut handling refuses to flush a privileged `local_shell` / `custom` call alongside a malformed sibling — emits `response.failed` only.
- 58 new tests across request translation, stream translation, and pre-stream error paths. Total suite: 111 pass / 0 fail.

Closes #1

Design doc: [`docs/superpowers/specs/2026-04-20-codex-responses-api-design.md`](https://github.com/xiaocheng139/copilot-api/blob/spec/codex-responses-api/docs/superpowers/specs/2026-04-20-codex-responses-api-design.md)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint:all` — clean
- [x] `bun test` — 111 pass / 0 fail across 7 files
- [ ] Manual smoke: `codex --base-url http://localhost:4141 --model claude-sonnet-4-5 "explain this repo"` alongside a concurrent Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)