### PR TITLE
feat: expose context window limits in /v1/models for Claude Code gateway discovery

### DIFF
--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -21,6 +21,9 @@ modelRoutes.get("/", async (c) => {
       created_at: new Date(0).toISOString(), // No date available from source
       owned_by: model.vendor,
       display_name: model.name,
+      // Anthropic Models API fields for Claude Code gateway model discovery
+      max_input_tokens: model.capabilities?.limits?.max_context_window_tokens,
+      max_tokens: model.capabilities?.limits?.max_output_tokens,
     }))
 
     return c.json({


### PR DESCRIPTION
## Summary
- Adds `max_input_tokens` and `max_tokens` fields to the `/v1/models` response, sourced from the upstream CAPI `capabilities.limits.max_context_window_tokens` and `max_output_tokens`
- Enables Claude Code's `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` to correctly detect the context window size from the proxy instead of falling back to hardcoded model defaults (which can be wrong — e.g., assuming 200k when CAPI reports 144k)
- Without this, Claude Code's autocompact triggers at the wrong threshold, causing either premature compaction or requests that exceed the actual upstream limit

## Context
GitHub's Copilot API (CAPI) already returns `capabilities.limits.max_context_window_tokens` for each model (the types are already defined in `get-models.ts`). This data just wasn't being passed through to the `/v1/models` response.

Claude Code added gateway model discovery in v2.1.129 and since March 2026 the Anthropic Models API returns `max_input_tokens` and `max_tokens`. This PR makes copilot-api compatible with that expectation.

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] Start copilot-api and verify `curl http://localhost:4141/v1/models` now includes `max_input_tokens` and `max_tokens` for each model
- [ ] Set `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` and verify Claude Code picks up the correct context window size