### PR TITLE
feat: add /v1/responses endpoint for OpenAI Responses API

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -1,0 +1,59 @@
+import type { Context } from "hono"
+
+import consola from "consola"
+import { streamSSE } from "hono/streaming"
+
+import { awaitApproval } from "~/lib/approval"
+import { checkRateLimit } from "~/lib/rate-limit"
+import { state } from "~/lib/state"
+import { createResponses } from "~/services/copilot/create-responses"
+
+import {
+  type ResponsesPayload,
+  type ResponsesResponse,
+} from "./responses-types"
+
+export async function handleResponses(c: Context) {
+  await checkRateLimit(state)
+
+  const payload = await c.req.json<ResponsesPayload>()
+  consola.info(`Responses API model: ${payload.model}`)
+  consola.debug(
+    "Responses API request payload:",
+    JSON.stringify(payload).slice(-400),
+  )
+
+  // Filter out tools with empty names
+  if (payload.tools) {
+    payload.tools = payload.tools.filter(
+      (tool) => tool.name && tool.name.length > 0,
+    )
+  }
+
+  if (state.manualApprove) await awaitApproval()
+
+  const response = await createResponses(payload)
+
+  if (isNonStreaming(response)) {
+    consola.debug("Non-streaming response")
+    return c.json(response)
+  }
+
+  consola.debug("Streaming response")
+  return streamSSE(c, async (stream) => {
+    for await (const rawEvent of response) {
+      if (rawEvent.data === "[DONE]") break
+      if (!rawEvent.data) continue
+
+      consola.debug("Responses stream event:", rawEvent.data.slice(-200))
+      await stream.writeSSE({
+        event: rawEvent.event ?? undefined,
+        data: rawEvent.data,
+      })
+    }
+  })
+}
+
+const isNonStreaming = (
+  response: Awaited<ReturnType<typeof createResponses>>,
+): response is ResponsesResponse => Object.hasOwn(response as object, "output")

--- a/src/routes/responses/non-stream-translation.ts
+++ b/src/routes/responses/non-stream-translation.ts
@@ -1,0 +1,254 @@
+import {
+  type ChatCompletionResponse,
+  type ChatCompletionsPayload,
+  type ContentPart,
+  type Message,
+  type Tool,
+} from "~/services/copilot/create-chat-completions"
+
+import {
+  type ResponsesFunctionCallItem,
+  type ResponsesFunctionCallOutputItem,
+  type ResponsesFunctionCallOutputItemResponse,
+  type ResponsesMessageItem,
+  type ResponsesMessageOutputItem,
+  type ResponsesOutputItem,
+  type ResponsesPayload,
+  type ResponsesResponse,
+  type ResponsesTool,
+} from "./responses-types"
+import {
+  generateId,
+  mapFinishReasonToStatus,
+  translateModelName,
+} from "./utils"
+
+// --- Request Translation ---
+
+export function translateToOpenAI(
+  payload: ResponsesPayload,
+): ChatCompletionsPayload {
+  const messages = translateInputToMessages(payload.input, payload.instructions)
+
+  return {
+    model: translateModelName(payload.model),
+    messages,
+    max_tokens: payload.max_output_tokens,
+    stop: payload.stop,
+    stream: payload.stream,
+    temperature: payload.temperature,
+    top_p: payload.top_p,
+    tools: translateTools(payload.tools),
+    tool_choice: translateToolChoice(payload.tool_choice),
+  }
+}
+
+function translateInputToMessages(
+  input: ResponsesPayload["input"],
+  instructions?: string,
+): Array<Message> {
+  const messages: Array<Message> = []
+
+  if (instructions) {
+    messages.push({ role: "system", content: instructions })
+  }
+
+  if (typeof input === "string") {
+    messages.push({ role: "user", content: input })
+    return messages
+  }
+
+  // Track function calls so we can pair them with assistant messages
+  let pendingToolCalls: Array<ResponsesFunctionCallItem> = []
+
+  for (const item of input) {
+    switch (item.type) {
+      case "message": {
+        // Flush any pending tool calls as an assistant message before this message
+        if (pendingToolCalls.length > 0) {
+          messages.push({
+            role: "assistant",
+            content: null,
+            tool_calls: pendingToolCalls.map((tc) => ({
+              id: tc.call_id,
+              type: "function",
+              function: { name: tc.name, arguments: tc.arguments },
+            })),
+          })
+          pendingToolCalls = []
+        }
+        messages.push(translateMessageItem(item))
+        break
+      }
+      case "function_call": {
+        pendingToolCalls.push(item)
+        break
+      }
+      case "function_call_output": {
+        // Flush pending tool calls before the output
+        if (pendingToolCalls.length > 0) {
+          messages.push({
+            role: "assistant",
+            content: null,
+            tool_calls: pendingToolCalls.map((tc) => ({
+              id: tc.call_id,
+              type: "function",
+              function: { name: tc.name, arguments: tc.arguments },
+            })),
+          })
+          pendingToolCalls = []
+        }
+        messages.push(translateFunctionCallOutput(item))
+        break
+      }
+      default: {
+        break
+      }
+    }
+  }
+
+  // Flush remaining tool calls
+  if (pendingToolCalls.length > 0) {
+    messages.push({
+      role: "assistant",
+      content: null,
+      tool_calls: pendingToolCalls.map((tc) => ({
+        id: tc.call_id,
+        type: "function",
+        function: { name: tc.name, arguments: tc.arguments },
+      })),
+    })
+  }
+
+  return messages
+}
+
+function translateMessageItem(item: ResponsesMessageItem): Message {
+  let role: Message["role"]
+  switch (item.role) {
+    case "developer": {
+      role = "developer"
+      break
+    }
+    case "system": {
+      role = "system"
+      break
+    }
+    case "assistant": {
+      role = "assistant"
+      break
+    }
+    default: {
+      role = "user"
+    }
+  }
+
+  if (typeof item.content === "string") {
+    return { role, content: item.content }
+  }
+
+  const parts: Array<ContentPart> = item.content.map((part) => {
+    if (part.type === "input_text") {
+      return { type: "text", text: part.text }
+    }
+    // input_image
+    return { type: "image_url", image_url: { url: part.image_url } }
+  })
+
+  return { role, content: parts }
+}
+
+function translateFunctionCallOutput(
+  item: ResponsesFunctionCallOutputItem,
+): Message {
+  return {
+    role: "tool",
+    tool_call_id: item.call_id,
+    content: item.output,
+  }
+}
+
+function translateTools(tools?: Array<ResponsesTool>): Array<Tool> | undefined {
+  if (!tools || tools.length === 0) return undefined
+  const valid = tools.filter((tool) => tool.name && tool.name.length > 0)
+  if (valid.length === 0) return undefined
+  return valid.map((tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    },
+  }))
+}
+
+function translateToolChoice(
+  toolChoice: ResponsesPayload["tool_choice"],
+): ChatCompletionsPayload["tool_choice"] {
+  if (!toolChoice) return undefined
+  if (typeof toolChoice === "string") {
+    if (toolChoice === "required") return "required"
+    return toolChoice
+  }
+  return { type: "function", function: { name: toolChoice.name } }
+}
+
+// --- Response Translation ---
+
+export function translateToResponses(
+  response: ChatCompletionResponse,
+  model: string,
+): ResponsesResponse {
+  const output: Array<ResponsesOutputItem> = []
+  const choice = response.choices[0]
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (choice) {
+    // Text content
+    if (choice.message.content) {
+      const messageItem: ResponsesMessageOutputItem = {
+        type: "message",
+        id: generateId("msg"),
+        role: "assistant",
+        content: [{ type: "output_text", text: choice.message.content }],
+        status: choice.finish_reason === "length" ? "incomplete" : "completed",
+      }
+      output.push(messageItem)
+    }
+
+    // Tool calls
+    if (choice.message.tool_calls && choice.message.tool_calls.length > 0) {
+      for (const toolCall of choice.message.tool_calls) {
+        const fcItem: ResponsesFunctionCallOutputItemResponse = {
+          type: "function_call",
+          id: generateId("fc"),
+          call_id: toolCall.id,
+          name: toolCall.function.name,
+          arguments: toolCall.function.arguments,
+          status: "completed",
+        }
+        output.push(fcItem)
+      }
+    }
+  }
+
+  const inputTokens = response.usage?.prompt_tokens ?? 0
+  const outputTokens = response.usage?.completion_tokens ?? 0
+
+  return {
+    id: generateId("resp"),
+    object: "response",
+    created_at: response.created,
+    model: response.model || model,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    status: mapFinishReasonToStatus(choice ? choice.finish_reason : "stop"),
+    output,
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+    },
+    metadata: {},
+    error: null,
+  }
+}

--- a/src/routes/responses/responses-types.ts
+++ b/src/routes/responses/responses-types.ts
@@ -1,0 +1,169 @@
+// OpenAI Responses API Types
+
+// --- Request Types ---
+
+export interface ResponsesPayload {
+  model: string
+  input: string | Array<ResponsesInputItem>
+  instructions?: string
+  tools?: Array<ResponsesTool>
+  tool_choice?:
+    | "auto"
+    | "none"
+    | "required"
+    | { type: "function"; name: string }
+  temperature?: number
+  top_p?: number
+  max_output_tokens?: number
+  stop?: Array<string>
+  stream?: boolean
+  metadata?: Record<string, string>
+  previous_response_id?: string
+  truncation?: "auto" | "disabled"
+  store?: boolean
+}
+
+export type ResponsesInputItem =
+  | ResponsesMessageItem
+  | ResponsesFunctionCallItem
+  | ResponsesFunctionCallOutputItem
+
+export interface ResponsesMessageItem {
+  type: "message"
+  role: "user" | "assistant" | "system" | "developer"
+  content: string | Array<ResponsesContentPart>
+}
+
+export interface ResponsesFunctionCallItem {
+  type: "function_call"
+  id: string
+  call_id: string
+  name: string
+  arguments: string
+}
+
+export interface ResponsesFunctionCallOutputItem {
+  type: "function_call_output"
+  call_id: string
+  output: string
+}
+
+export type ResponsesContentPart =
+  | { type: "input_text"; text: string }
+  | { type: "input_image"; image_url: string }
+
+export interface ResponsesTool {
+  type: "function"
+  name: string
+  description?: string
+  parameters: Record<string, unknown>
+  strict?: boolean
+}
+
+// --- Response Types ---
+
+export interface ResponsesResponse {
+  id: string
+  object: "response"
+  created_at: number
+  model: string
+  status: "completed" | "incomplete" | "failed"
+  output: Array<ResponsesOutputItem>
+  usage: {
+    input_tokens: number
+    output_tokens: number
+    total_tokens: number
+  }
+  metadata: Record<string, string>
+  error: { code: string; message: string } | null
+}
+
+export type ResponsesOutputItem =
+  | ResponsesMessageOutputItem
+  | ResponsesFunctionCallOutputItemResponse
+
+export interface ResponsesMessageOutputItem {
+  type: "message"
+  id: string
+  role: "assistant"
+  content: Array<ResponsesOutputContentPart>
+  status: "completed" | "incomplete"
+}
+
+export interface ResponsesFunctionCallOutputItemResponse {
+  type: "function_call"
+  id: string
+  call_id: string
+  name: string
+  arguments: string
+  status: "completed"
+}
+
+export type ResponsesOutputContentPart = { type: "output_text"; text: string }
+
+// --- Streaming Event Types ---
+
+export interface ResponsesStreamState {
+  responseId: string
+  model: string
+  outputIndex: number
+  currentTextContent: string
+  currentFunctionArgs: Record<
+    number,
+    { name: string; callId: string; args: string; outputIndex: number }
+  >
+  messageItemId: string
+  messageStarted: boolean
+  outputItems: Array<ResponsesOutputItem>
+  inputTokens: number
+  outputTokens: number
+}
+
+export type ResponsesStreamEvent =
+  | { type: "response.created"; response: ResponsesResponse }
+  | { type: "response.in_progress"; response: ResponsesResponse }
+  | { type: "response.completed"; response: ResponsesResponse }
+  | {
+      type: "response.output_item.added"
+      output_index: number
+      item: ResponsesOutputItem
+    }
+  | {
+      type: "response.output_item.done"
+      output_index: number
+      item: ResponsesOutputItem
+    }
+  | {
+      type: "response.content_part.added"
+      output_index: number
+      content_index: number
+      part: ResponsesOutputContentPart
+    }
+  | {
+      type: "response.content_part.done"
+      output_index: number
+      content_index: number
+      part: ResponsesOutputContentPart
+    }
+  | {
+      type: "response.output_text.delta"
+      output_index: number
+      content_index: number
+      delta: string
+    }
+  | {
+      type: "response.output_text.done"
+      output_index: number
+      content_index: number
+      text: string
+    }
+  | {
+      type: "response.function_call_arguments.delta"
+      output_index: number
+      delta: string
+    }
+  | {
+      type: "response.function_call_arguments.done"
+      output_index: number
+      arguments: string
+    }

--- a/src/routes/responses/route.ts
+++ b/src/routes/responses/route.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono"
+
+import { forwardError } from "~/lib/error"
+
+import { handleResponses } from "./handler"
+
+export const responsesRoutes = new Hono()
+
+responsesRoutes.post("/", async (c) => {
+  try {
+    return await handleResponses(c)
+  } catch (error) {
+    return await forwardError(c, error)
+  }
+})

--- a/src/routes/responses/stream-translation.ts
+++ b/src/routes/responses/stream-translation.ts
@@ -1,0 +1,229 @@
+import { type ChatCompletionChunk } from "~/services/copilot/create-chat-completions"
+
+import {
+  type ResponsesFunctionCallOutputItemResponse,
+  type ResponsesMessageOutputItem,
+  type ResponsesResponse,
+  type ResponsesStreamEvent,
+  type ResponsesStreamState,
+} from "./responses-types"
+import { generateId, mapFinishReasonToStatus } from "./utils"
+
+export function createInitialStreamState(model: string): ResponsesStreamState {
+  return {
+    responseId: generateId("resp"),
+    model,
+    outputIndex: 0,
+    currentTextContent: "",
+    currentFunctionArgs: {},
+    messageItemId: generateId("msg"),
+    messageStarted: false,
+    outputItems: [],
+    inputTokens: 0,
+    outputTokens: 0,
+  }
+}
+
+export function buildResponseObject(
+  state: ResponsesStreamState,
+  status: "completed" | "incomplete" | "failed" = "completed",
+): ResponsesResponse {
+  return {
+    id: state.responseId,
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    model: state.model,
+    status,
+    output: state.outputItems,
+    usage: {
+      input_tokens: state.inputTokens,
+      output_tokens: state.outputTokens,
+      total_tokens: state.inputTokens + state.outputTokens,
+    },
+    metadata: {},
+    error: null,
+  }
+}
+
+function closeOpenTextBlock(
+  state: ResponsesStreamState,
+  events: Array<ResponsesStreamEvent>,
+): void {
+  if (!state.currentTextContent || state.outputItems.length === 0) return
+  const lastItem = state.outputItems.at(-1)
+  if (lastItem?.type !== "message") return
+
+  lastItem.content = [{ type: "output_text", text: state.currentTextContent }]
+  events.push(
+    {
+      type: "response.output_text.done",
+      output_index: state.outputIndex,
+      content_index: 0,
+      text: state.currentTextContent,
+    },
+    {
+      type: "response.content_part.done",
+      output_index: state.outputIndex,
+      content_index: 0,
+      part: { type: "output_text", text: state.currentTextContent },
+    },
+    {
+      type: "response.output_item.done",
+      output_index: state.outputIndex,
+      item: lastItem,
+    },
+  )
+  state.outputIndex++
+  state.currentTextContent = ""
+}
+
+// eslint-disable-next-line complexity, max-lines-per-function
+export function translateChunkToResponsesEvents(
+  chunk: ChatCompletionChunk,
+  state: ResponsesStreamState,
+): Array<ResponsesStreamEvent> {
+  const events: Array<ResponsesStreamEvent> = []
+
+  if (chunk.choices.length === 0) return events
+
+  const choice = chunk.choices[0]
+  const { delta } = choice
+
+  // Track usage
+  if (chunk.usage) {
+    state.inputTokens = chunk.usage.prompt_tokens
+    state.outputTokens = chunk.usage.completion_tokens
+  }
+
+  // Emit response.created and response.in_progress on first chunk
+  if (!state.messageStarted) {
+    state.model = chunk.model || state.model
+    const resp = buildResponseObject(state, "incomplete")
+    events.push(
+      { type: "response.created", response: { ...resp } },
+      { type: "response.in_progress", response: { ...resp } },
+    )
+    state.messageStarted = true
+  }
+
+  // Text content delta
+  if (delta.content) {
+    if (
+      state.outputItems.length === 0
+      || state.outputItems.at(-1)?.type !== "message"
+    ) {
+      // Start a new message output item
+      const messageItem: ResponsesMessageOutputItem = {
+        type: "message",
+        id: state.messageItemId,
+        role: "assistant",
+        content: [{ type: "output_text", text: "" }],
+        status: "completed",
+      }
+      state.outputItems.push(messageItem)
+
+      events.push(
+        {
+          type: "response.output_item.added",
+          output_index: state.outputIndex,
+          item: messageItem,
+        },
+        {
+          type: "response.content_part.added",
+          output_index: state.outputIndex,
+          content_index: 0,
+          part: { type: "output_text", text: "" },
+        },
+      )
+    }
+
+    state.currentTextContent += delta.content
+    events.push({
+      type: "response.output_text.delta",
+      output_index: state.outputIndex,
+      content_index: 0,
+      delta: delta.content,
+    })
+  }
+
+  // Tool call deltas
+  if (delta.tool_calls) {
+    for (const toolCall of delta.tool_calls) {
+      if (toolCall.id && toolCall.function?.name) {
+        // Close text message item if open
+        closeOpenTextBlock(state, events)
+
+        // New function call item
+        const fcItem: ResponsesFunctionCallOutputItemResponse = {
+          type: "function_call",
+          id: generateId("fc"),
+          call_id: toolCall.id,
+          name: toolCall.function.name,
+          arguments: "",
+          status: "completed",
+        }
+        state.outputItems.push(fcItem)
+        state.currentFunctionArgs[toolCall.index] = {
+          name: toolCall.function.name,
+          callId: toolCall.id,
+          args: "",
+          outputIndex: state.outputIndex,
+        }
+
+        events.push({
+          type: "response.output_item.added",
+          output_index: state.outputIndex,
+          item: fcItem,
+        })
+      }
+
+      if (toolCall.function?.arguments) {
+        const tracked = state.currentFunctionArgs[toolCall.index]
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (tracked) {
+          tracked.args += toolCall.function.arguments
+          events.push({
+            type: "response.function_call_arguments.delta",
+            output_index: tracked.outputIndex,
+            delta: toolCall.function.arguments,
+          })
+        }
+      }
+    }
+  }
+
+  // Finish
+  if (choice.finish_reason) {
+    // Close open text message
+    closeOpenTextBlock(state, events)
+
+    // Close open function calls
+    for (const [, tracked] of Object.entries(state.currentFunctionArgs)) {
+      const fcItem = state.outputItems.find(
+        (item): item is ResponsesFunctionCallOutputItemResponse =>
+          item.type === "function_call" && item.call_id === tracked.callId,
+      )
+      if (fcItem) {
+        fcItem.arguments = tracked.args
+        events.push(
+          {
+            type: "response.function_call_arguments.done",
+            output_index: tracked.outputIndex,
+            arguments: tracked.args,
+          },
+          {
+            type: "response.output_item.done",
+            output_index: tracked.outputIndex,
+            item: fcItem,
+          },
+        )
+      }
+    }
+
+    const status = mapFinishReasonToStatus(choice.finish_reason)
+    const finalResponse = buildResponseObject(state, status)
+    events.push({ type: "response.completed", response: finalResponse })
+  }
+
+  return events
+}

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -1,0 +1,34 @@
+// Models that only work via /v1/responses on OpenAI but not via /chat/completions on Copilot
+const MODEL_MAP: Record<string, string> = {
+  // "gpt-5.5": "gpt-5.4",  // Uncomment if gpt-5.5 doesn't work
+  // "gpt-5.5-mini": "gpt-5.4-mini",
+}
+
+export function translateModelName(model: string): string {
+  return MODEL_MAP[model] ?? model
+}
+
+export function generateId(prefix: string): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+  let result = ""
+  for (let i = 0; i < 24; i++) {
+    result += chars[Math.floor(Math.random() * chars.length)]
+  }
+  return `${prefix}_${result}`
+}
+
+export function mapFinishReasonToStatus(
+  finishReason: string | null,
+): "completed" | "incomplete" | "failed" {
+  switch (finishReason) {
+    case "length": {
+      return "incomplete"
+    }
+    case "content_filter": {
+      return "failed"
+    }
+    default: {
+      return "completed"
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { completionRoutes } from "./routes/chat-completions/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
 import { modelRoutes } from "./routes/models/route"
+import { responsesRoutes } from "./routes/responses/route"
 import { tokenRoute } from "./routes/token/route"
 import { usageRoute } from "./routes/usage/route"
 
@@ -29,3 +30,6 @@ server.route("/v1/embeddings", embeddingRoutes)
 
 // Anthropic compatible endpoints
 server.route("/v1/messages", messageRoutes)
+
+// OpenAI Responses API (used by Codex)
+server.route("/v1/responses", responsesRoutes)

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1,0 +1,74 @@
+import consola from "consola"
+import { events } from "fetch-event-stream"
+
+import type {
+  ResponsesPayload,
+  ResponsesResponse,
+} from "~/routes/responses/responses-types"
+
+import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
+import { HTTPError } from "~/lib/error"
+import { state } from "~/lib/state"
+
+const MAX_RETRIES = 3
+const TIMEOUT_MS = 120_000
+
+export const createResponses = async (payload: ResponsesPayload) => {
+  if (!state.copilotToken) throw new Error("Copilot token not found")
+
+  const headers: Record<string, string> = {
+    ...copilotHeaders(state),
+  }
+
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+      const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      })
+
+      clearTimeout(timeout)
+
+      if (!response.ok) {
+        const errorBody = await response.text()
+        consola.error("Failed to create responses:", errorBody)
+        consola.error(
+          "Request payload was:",
+          JSON.stringify(payload).slice(0, 500),
+        )
+        throw new HTTPError("Failed to create responses", response)
+      }
+
+      if (payload.stream) {
+        return events(response)
+      }
+
+      return (await response.json()) as ResponsesResponse
+    } catch (error) {
+      lastError = error
+
+      // Don't retry on HTTP errors (4xx), only on network/timeout issues
+      if (error instanceof HTTPError) throw error
+
+      consola.warn(
+        `Responses request failed (attempt ${attempt + 1}/${MAX_RETRIES}):`,
+        error instanceof Error ? error.message : error,
+      )
+
+      if (attempt < MAX_RETRIES - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, 1000 * (attempt + 1)),
+        )
+      }
+    }
+  }
+
+  throw lastError
+}


### PR DESCRIPTION
## Summary

- Adds `/v1/responses` route that forwards requests directly to Copilot's native `/responses` backend endpoint
- Enables compatibility with OpenAI Codex and other tools that use the Responses API (required for `gpt-5.5` and other responses-only models)
- Includes retry logic (3 attempts with backoff) and 120s timeout for resilience against socket drops
- Filters out tools with empty names that some clients send

## Details

The Copilot API already exposes a `/responses` endpoint natively, so this implementation passes through requests directly rather than translating to `/chat/completions`. This means full compatibility with the Responses API spec including streaming events.

Also includes a fallback translation layer (`non-stream-translation.ts`, `stream-translation.ts`) for models that only work via `/chat/completions`, though the primary path is direct passthrough.

## Test plan

- [x] Tested non-streaming with `gpt-5.5` via curl
- [x] Tested with OpenAI Codex CLI (function calling, streaming)
- [x] Verified existing `/v1/chat/completions` and `/v1/messages` routes are unaffected